### PR TITLE
c++: Add defaults to type table

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -237,6 +237,8 @@ struct TypeTable {
   const int16_t *array_sizes;     // less than num_elems entries (see TypeCode).
   const int64_t *values;  // Only set for non-consecutive enum/union or structs.
   const char *const *names;  // Only set if compiled with --reflect-names.
+  const char *const *default_value_token;  // String version of default values.
+  // value.
 };
 
 // String which identifies the current version of FlatBuffers.


### PR DESCRIPTION
This change adds default string values to the TypeTable for all generated cpp code.

The type table is used by minireflect.h to provide names for fields (and now default values), we primarily use it to convert values to JSON. Without the default values here though we can only populate fields that have set values, and values that happen to equal the defaults aren't "set".