### PR TITLE
Added pybind code generation support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,9 @@ option(FLATBUFFERS_SKIP_MONSTER_EXTRA
 option(FLATBUFFERS_STRICT_MODE
       "Build flatbuffers with all warnings as errors (-Werror or /WX)."
       OFF)
+option(FLATBUFFERS_ENABLE_PYBIND
+      "Include pybind11 support in the flatbuffers library."
+      OFF)
 
 if(NOT DEFINED FLATBUFFERS_CPP_STD)
   set(FLATBUFFERS_CPP_STD 11)
@@ -152,6 +155,12 @@ set(FlatBuffers_Library_SRCS
   src/util.cpp
 )
 
+if (FLATBUFFERS_ENABLE_PYBIND)
+  list(APPEND FlatBuffers_Library_SRCS pybind/include/flatbuffers/pybind/bind_array.h)
+  list(APPEND FlatBuffers_Library_SRCS pybind/include/flatbuffers/pybind/casters.h)
+  list(APPEND FlatBuffers_Library_SRCS pybind/include/flatbuffers/pybind/memory.h)
+endif()
+
 set(FlatBuffers_Compiler_SRCS
   ${FlatBuffers_Library_SRCS}
   src/idl_gen_binary.cpp
@@ -165,6 +174,7 @@ set(FlatBuffers_Compiler_SRCS
   src/idl_gen_java.cpp
   src/idl_gen_ts.cpp
   src/idl_gen_php.cpp
+  src/idl_gen_pybind.cpp
   src/idl_gen_python.cpp
   src/idl_gen_lobster.cpp
   src/idl_gen_rust.cpp
@@ -427,6 +437,12 @@ else()
   endif()
 endif()
 
+if (FLATBUFFERS_ENABLE_PYBIND)
+  find_package(Python COMPONENTS Interpreter Development)
+  find_package(pybind11 CONFIG REQUIRED)
+  include_directories(pybind/include)
+endif()
+
 if(FLATBUFFERS_BUILD_FLATLIB)
   add_library(flatbuffers STATIC ${FlatBuffers_Library_SRCS})
 
@@ -488,9 +504,9 @@ if(FLATBUFFERS_BUILD_SHAREDLIB)
   endif()
 endif()
 
-function(compile_schema SRC_FBS OPT OUT_GEN_FILE) 
+function(compile_schema SRC_FBS OPT GEN_EXT OUT_GEN_FILE)
   get_filename_component(SRC_FBS_DIR ${SRC_FBS} PATH)
-  string(REGEX REPLACE "\\.fbs$" "_generated.h" GEN_HEADER ${SRC_FBS})
+  string(REGEX REPLACE "\\.fbs$" "_generated.${GEN_EXT}" GEN_HEADER ${SRC_FBS})
   add_custom_command(
     OUTPUT ${GEN_HEADER}
     COMMAND "${FLATBUFFERS_FLATC_EXECUTABLE}"
@@ -504,13 +520,20 @@ function(compile_schema SRC_FBS OPT OUT_GEN_FILE)
 endfunction()
 
 function(compile_schema_for_test SRC_FBS OPT)
-  compile_schema("${SRC_FBS}" "${OPT}" GEN_FILE)
+  compile_schema("${SRC_FBS}" "${OPT}" "h" GEN_FILE)
   target_sources(flattests PRIVATE ${GEN_FILE})
 endfunction()
 
 function(compile_schema_for_samples SRC_FBS OPT)
-  compile_schema("${SRC_FBS}" "${OPT}" GEN_FILE)
+  compile_schema("${SRC_FBS}" "${OPT}" "h" GEN_FILE)
   target_sources(flatsample PRIVATE ${GEN_FILE})
+endfunction()
+
+function(compile_schema_for_pybind TARGET_NAME SRC_FBS PYBIND_OPT)
+  compile_schema("${SRC_FBS}" "${PYBIND_OPT}" "cpp" PYBIND_GEN_FILE)
+  pybind11_add_module("${TARGET_NAME}" "${PYBIND_GEN_FILE}")
+  target_include_directories("${TARGET_NAME}" PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+  target_compile_features("${TARGET_NAME}" PRIVATE cxx_std_17) # requires cmake 3.8
 endfunction()
 
 if(FLATBUFFERS_BUILD_TESTS)
@@ -581,6 +604,21 @@ if(FLATBUFFERS_BUILD_TESTS)
       add_fsanitize_to_target(flattests_cpp17 ${FLATBUFFERS_CODE_SANITIZE})
     endif()
   endif(FLATBUFFERS_BUILD_CPP17)
+
+  if(FLATBUFFERS_ENABLE_PYBIND)
+    SET(FLATC_PYBIND_OPT --pybind --gen-mutable --gen-object-api --reflect-names)
+    SET(FLATC_PYBIND_OPT_SCOPED_ENUMS ${FLATC_PYBIND_OPT};--scoped-enums)
+    compile_schema_for_pybind(alignment_test_generated tests/alignment_test.fbs "${FLATC_PYBIND_OPT}")
+    compile_schema_for_pybind(arrays_test_generated tests/arrays_test.fbs "${FLATC_PYBIND_OPT_SCOPED_ENUMS}")
+    compile_schema_for_pybind(key_field_sample_generated tests/key_field/key_field_sample.fbs "${FLATC_PYBIND_OPT}")
+
+    compile_schema_for_pybind(monster_generated samples/monster.fbs "${FLATC_PYBIND_OPT}")
+
+    # TODO(michaelahn): Add more test coverage.
+    # SET(FLATC_TEST_INCL_OPT -I "${CMAKE_CURRENT_SOURCE_DIR}/tests/include_test")
+    # compile_schema_for_test(tests/monster_test.fbs "${FLATC_OPT_SCOPED_ENUMS};${FLATC_TEST_INCL_OPT}")
+    # compile_schema_for_pybind(monster_test_generated tests/monster_test.fbs "${FLATC_PYBIND_OPT_SCOPED_ENUMS};${FLATC_TEST_INCL_OPT}")
+  endif(FLATBUFFERS_ENABLE_PYBIND)
 endif()
 
 if(FLATBUFFERS_BUILD_GRPCTEST)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -167,3 +167,22 @@ http_file(
         "https://github.com/bazelbuild/bazel/releases/download/6.3.2/bazel-6.3.2-linux-x86_64",
     ],
 )
+
+http_archive(
+    name = "pybind11_bazel",
+    sha256 = "b72c5b44135b90d1ffaba51e08240be0b91707ac60bea08bb4d84b47316211bb",
+    strip_prefix = "pybind11_bazel-b162c7c88a253e3f6b673df0c621aca27596ce6b",
+    url = "https://github.com/pybind/pybind11_bazel/archive/b162c7c88a253e3f6b673df0c621aca27596ce6b.zip",
+)
+
+http_archive(
+    name = "pybind11",
+    build_file = "@pybind11_bazel//:pybind11.BUILD",
+    sha256 = "111014b516b625083bef701df7880f78c2243835abdb263065b6b59b960b6bad",
+    strip_prefix = "pybind11-2.10.1",
+    url = "https://github.com/pybind/pybind11/archive/refs/tags/v2.10.1.tar.gz",
+)
+
+load("@pybind11_bazel//:python_configure.bzl", "python_configure")
+
+python_configure(name = "local_config_python")

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -709,6 +709,7 @@ struct IDLOptions {
   bool python_typing;
   bool ts_omit_entrypoint;
   ProtoIdGapAction proto_id_gap_action;
+  std::string pybind_include_filename_suffix;
 
   // Possible options for the more general generator below.
   enum Language {
@@ -731,6 +732,7 @@ struct IDLOptions {
     kNim = 1 << 17,
     kProto = 1 << 18,
     kKotlinKmp = 1 << 19,
+    kPybind = 1 << 20,
     kMAX
   };
 

--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -389,6 +389,7 @@ class span FLATBUFFERS_FINAL_CLASS {
       FLATBUFFERS_NOEXCEPT {
     data_ = other.data_;
     count_ = other.count_;
+    return *this;
   }
 
   // Limited implementation of
@@ -466,7 +467,7 @@ class span FLATBUFFERS_FINAL_CLASS {
 
  private:
   // This is a naive implementation with 'count_' member even if (Extent != dynamic_extent).
-  pointer const data_;
+  pointer data_;
   size_type count_;
 };
 #endif  // defined(FLATBUFFERS_USE_STD_SPAN)

--- a/pybind/BUILD.bazel
+++ b/pybind/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@pybind11_bazel//:build_defs.bzl", "pybind_library")
+
+package(default_visibility = ["//visibility:public"])
+
+pybind_library(
+    name = "pybind",
+    hdrs = glob([
+        "include/flatbuffers/pybind/*.h",
+    ]),
+    includes = ["include"],
+)

--- a/pybind/build_defs.bzl
+++ b/pybind/build_defs.bzl
@@ -1,0 +1,64 @@
+"""Build rules for flatbuffers-generated pybind code."""
+
+load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
+load("@rules_python//python:defs.bzl", "py_library")
+load("//:new_build_defs.bzl", "flatc_generated_files")
+
+DEFAULT_COPTS = [
+    "-std=c++17",
+    "-Wno-unused-local-typedef",
+]
+
+def flatbuffer_pybind_library(
+        name,
+        srcs,
+        cc_deps = [],
+        py_deps = [],
+        flatc_data = [],
+        copts = DEFAULT_COPTS,
+        filename_suffix = None,
+        flatc_args = None,
+        flatc = None,
+        **kwargs):
+    """A py_library which generates and compiles flatbuffers pybind code.
+
+    Args:
+        name: Rule name.
+        srcs: Source .fbs files.
+        cc_deps: `flatbuffer_cc_library` targets which correspond to the flatbuffer files in srcs.
+        py_deps: Python dependencies for generated pybind code. This can include other
+            `flatbuffer_pybind_library` targets whose flatbuffer files are imported by `srcs`, and
+            other `py_library` targets (e.g. libraries referenced by `flatc_args`).
+        flatc_data: Additional files to make visible to flatc when generating code. (e.g. files
+            specified by `--cpp-include`).
+        copts: C++ compiler options for compiling the pybind extension.
+        filename_suffix: Overrides the default filename suffix ("_generated") for generated files.
+        flatc_args: Overrides the arguments to pass to flatc.
+        flatc: Overrides the flatc executable.
+        **kwargs: Additional arguments to pass to `py_library`.
+    """
+    gen_target_name = "%s_srcs" % name
+    flatc_generated_files(
+        name = gen_target_name,
+        srcs = srcs,
+        language = "pybind",
+        deps = cc_deps + py_deps + flatc_data,
+        filename_suffix = filename_suffix,
+        flatc_args = flatc_args,
+        flatc = flatc,
+    )
+    pybind_extension(
+        name = name,  # This creates a {name}.so target.
+        srcs = [":%s" % gen_target_name],
+        copts = copts,
+        deps = [
+            "@com_github_google_flatbuffers//pybind",
+        ] + cc_deps,
+    )
+    py_library(
+        name = name,
+        deps = [
+            ":%s.so" % (name),
+        ] + py_deps,
+        **kwargs
+    )

--- a/pybind/include/flatbuffers/pybind/bind_array.h
+++ b/pybind/include/flatbuffers/pybind/bind_array.h
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2024 Figure AI, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLATBUFFERS_PYBIND_BIND_ARRAY_H_
+#define FLATBUFFERS_PYBIND_BIND_ARRAY_H_
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl_bind.h>
+
+#include <type_traits>
+
+namespace flatbuffers {
+namespace pybind {
+
+namespace detail {
+
+// Checks if the given type has an `element_type` member (e.g. smart pointers).
+template<typename, typename = void>
+struct has_element_type : std::false_type {};
+
+template<typename T>
+struct has_element_type<T, std::void_t<typename T::element_type>>
+    : std::true_type {};
+
+// Type information for scalar types.
+template<typename T, typename = void> struct ElementTypeHelper {
+  using return_type = T;
+  using const_arg_type = T;
+
+  static constexpr pybind11::return_value_policy policy =
+      pybind11::return_value_policy::automatic;
+
+  static inline return_type GetReturnValue(T value) { return value; }
+
+  static inline T NewItem() { return T(); }
+  static inline const T NewItem(const_arg_type value) { return value; }
+};
+
+// For holder types (e.g. smart pointers).
+template<typename T>
+struct ElementTypeHelper<
+    T, typename std::enable_if<has_element_type<T>::value>::type> {
+  using return_type = typename T::element_type *;
+  using const_arg_type = typename T::element_type &;
+
+  static constexpr pybind11::return_value_policy policy =
+      pybind11::return_value_policy::reference_internal;
+
+  static inline return_type GetReturnValue(const T &value) {
+    return value.get();
+  }
+
+  static inline T NewItem() { return T(new typename T::element_type()); }
+  static inline T NewItem(const_arg_type value) {
+    return T(new typename T::element_type(value));
+  }
+};
+
+// For raw pointers of scalars.
+template<typename T>
+struct ElementTypeHelper<
+    T,
+    typename std::enable_if<
+        std::is_pointer<T>::value &&
+        std::is_scalar<typename std::remove_pointer<T>::type>::value>::type> {
+  using value_type = typename std::remove_pointer<T>::type;
+  using return_type = value_type;
+  using const_arg_type = value_type;
+
+  static constexpr pybind11::return_value_policy policy =
+      pybind11::return_value_policy::automatic;
+
+  static inline value_type GetReturnValue(T value) { return *value; }
+  // No `NewItem`; arrays are never resizable.
+};
+
+// For raw pointers of non-scalars (e.g. arrays of structs).
+template<typename T>
+struct ElementTypeHelper<
+    T,
+    typename std::enable_if<
+        std::is_pointer<T>::value &&
+        !std::is_scalar<typename std::remove_pointer<T>::type>::value>::type> {
+  using value_type = typename std::remove_pointer<T>::type;
+  using return_type = value_type *;
+  using const_arg_type = const value_type &;
+
+  static constexpr pybind11::return_value_policy policy =
+      pybind11::return_value_policy::reference_internal;
+
+  static inline T GetReturnValue(T value) { return value; }
+  // No `NewItem`; arrays are never resizable.
+};
+
+// For value-types (e.g. vectors of structs).
+template<typename T>
+struct ElementTypeHelper<
+    T, typename std::enable_if<!has_element_type<T>::value &&
+                               !std::is_scalar<T>::value>::type> {
+  using return_type = T *;
+  using const_arg_type = const T &;
+
+  static constexpr pybind11::return_value_policy policy =
+      pybind11::return_value_policy::reference_internal;
+
+  static inline const T *GetReturnValue(const T &value) { return &value; }
+  static inline T *GetReturnValue(T &value) { return &value; }
+
+  static inline T NewItem() { return T(); }
+  static inline const T &NewItem(const_arg_type value) { return value; }
+};
+
+// Returns the return type of operator[] for the templated type.
+template<typename T>
+using item_type_t = std::remove_reference_t<
+    decltype(std::declval<T>()[std::declval<size_t>()])>;
+
+inline size_t WrapIndexOrThrow(ssize_t idx, size_t size) {
+  ssize_t new_idx = idx;
+  if (new_idx < 0) { new_idx += size; }
+  if (new_idx < 0 || new_idx >= size) {
+    throw pybind11::index_error(
+        pybind11::str("Index {} out of range for size: {}").format(idx, size));
+  }
+  return new_idx;
+}
+
+template<typename ArrayT, typename PyClass>
+inline void BindReadOperations(PyClass &c) {
+  using item_type = item_type_t<ArrayT>;
+  using TypeHelper = detail::ElementTypeHelper<item_type>;
+
+  c.def("__len__", &ArrayT::size);
+  c.def("__bool__", [](const ArrayT &self) { return self.size() > 0; });
+
+  c.def(
+      "__getitem__",
+      [](ArrayT &self, ssize_t i) {
+        return TypeHelper::GetReturnValue(
+            self[detail::WrapIndexOrThrow(i, self.size())]);
+      },
+      TypeHelper::policy);
+}
+
+template<typename ArrayT, typename PyClass>
+inline void BindFbsWriteOperations(PyClass &c) {
+  using item_type = item_type_t<ArrayT>;
+  using TypeHelper = detail::ElementTypeHelper<item_type>;
+
+  c.def("__setitem__",
+        [](ArrayT &self, ssize_t i, typename TypeHelper::const_arg_type value) {
+          self.Mutate(detail::WrapIndexOrThrow(i, self.size()), value);
+        });
+}
+
+template<typename ArrayT, typename PyClass>
+inline void BindStdVectorWriteOperations(PyClass &c) {
+  using item_type = item_type_t<ArrayT>;
+  using TypeHelper = detail::ElementTypeHelper<item_type>;
+
+  c.def("__setitem__", [](ArrayT &self, ssize_t i,
+                          typename TypeHelper::const_arg_type v) {
+    self[detail::WrapIndexOrThrow(i, self.size())] = TypeHelper::NewItem(v);
+  });
+
+  // Copy appending.
+  c.def("append", [](ArrayT &self, typename TypeHelper::const_arg_type value) {
+    self.push_back(TypeHelper::NewItem(value));
+  });
+
+  // In-place appending an element.
+  c.def(
+      "add",
+      [](ArrayT &self) {
+        return TypeHelper::GetReturnValue(
+            self.emplace_back(TypeHelper::NewItem()));
+      },
+      pybind11::return_value_policy::reference_internal);
+
+  c.def("reserve", [](ArrayT &self, size_t size) { self.reserve(size); });
+  c.def("resize", [](ArrayT &self, size_t size) { self.resize(size); });
+}
+
+template<typename ArrayT, typename PyClass>
+inline void BindArithmeticOperations(PyClass &c) {
+  using item_type = item_type_t<ArrayT>;
+
+  // Check that the storage type is numpy-compatible.
+  pybind11::format_descriptor<item_type>::format();
+
+  c.def_buffer([](ArrayT &self) -> pybind11::buffer_info {
+    return pybind11::buffer_info(
+        self.data(), static_cast<ssize_t>(sizeof(item_type)),
+        pybind11::format_descriptor<item_type>::format(), 1, { self.size() },
+        { sizeof(item_type) });
+  });
+
+  c.def("numpy", [](pybind11::handle self) {
+    const ArrayT &self_cpp = pybind11::cast<const ArrayT &>(self);
+    return pybind11::array(pybind11::dtype::of<item_type>(), self_cpp.size(),
+                           self_cpp.data(), self);
+  });
+}
+
+}  // namespace detail
+
+// Binds a ::flatbuffers::Array or ::flatbuffers::Vector.
+template<typename ArrayT>
+inline void BindArrayReadonly(pybind11::handle scope, const char *name) {
+  using PyClass = pybind11::class_<ArrayT>;
+  PyClass c(scope, name, pybind11::module_local());
+  detail::BindReadOperations<ArrayT, PyClass>(c);
+}
+
+// Binds a ::flatbuffers::Array or ::flatbuffers::Vector.
+template<typename ArrayT>
+inline void BindArrayReadwrite(pybind11::handle scope, const char *name) {
+  using PyClass = pybind11::class_<ArrayT>;
+  PyClass c(scope, name, pybind11::module_local());
+  detail::BindReadOperations<ArrayT, PyClass>(c);
+  detail::BindFbsWriteOperations<ArrayT, PyClass>(c);
+}
+
+// Binds a ::flatbuffers::Array or ::flatbuffers::Vector whose data type is
+// arithmetic.
+template<typename ArrayT>
+inline void BindArrayArithmetic(pybind11::handle scope, const char *name) {
+  using PyClass = pybind11::class_<ArrayT>;
+  PyClass c(scope, name, pybind11::module_local(), pybind11::buffer_protocol());
+  detail::BindReadOperations<ArrayT, PyClass>(c);
+  detail::BindFbsWriteOperations<ArrayT, PyClass>(c);
+  detail::BindArithmeticOperations<ArrayT, PyClass>(c);
+}
+
+// Binds a std::vector (e.g. for object API vector fields).
+template<typename ArrayT>
+inline void BindStdVector(pybind11::handle scope, const char *name) {
+  using PyClass = pybind11::class_<ArrayT>;
+  PyClass c(scope, name, pybind11::module_local());
+  detail::BindReadOperations<ArrayT, PyClass>(c);
+  detail::BindStdVectorWriteOperations<ArrayT, PyClass>(c);
+}
+
+// Binds a std::vector (e.g. for object API vector fields) whose data type is
+// arithmetic.
+template<typename ArrayT>
+inline void BindStdVectorArithmetic(pybind11::handle scope, const char *name) {
+  using PyClass = pybind11::class_<ArrayT>;
+  PyClass c(scope, name, pybind11::module_local(), pybind11::buffer_protocol());
+  detail::BindReadOperations<ArrayT, PyClass>(c);
+  detail::BindStdVectorWriteOperations<ArrayT, PyClass>(c);
+  detail::BindArithmeticOperations<ArrayT, PyClass>(c);
+}
+
+}  // namespace pybind
+}  // namespace flatbuffers
+
+#endif  // FLATBUFFERS_PYBIND_BIND_ARRAY_H_

--- a/pybind/include/flatbuffers/pybind/casters.h
+++ b/pybind/include/flatbuffers/pybind/casters.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2024 Figure AI, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLATBUFFERS_PYBIND_CASTERS_H_
+#define FLATBUFFERS_PYBIND_CASTERS_H_
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <array>
+#include <type_traits>
+#include <vector>
+
+#include "flatbuffers/pybind/memory.h"
+#include "flatbuffers/stl_emulation.h"
+#include "flatbuffers/string.h"
+
+PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+PYBIND11_NAMESPACE_BEGIN(detail)
+
+namespace internal {
+
+template<typename C>
+using has_resize_method =
+    std::is_same<decltype(std::declval<C>().resize(0)), void>;
+
+template<typename C,
+         typename std::enable_if<has_resize_method<C>::value, int>::type = 0>
+void resize_maybe(C *container, size_t size) {
+  container->resize(size);
+}
+void resize_maybe(void *container, size_t) {}
+
+}  // namespace internal
+
+template<typename SpanType, typename Value,
+         std::size_t Extent = flatbuffers::dynamic_extent>
+struct span_caster {
+  using value_conv = make_caster<Value>;
+  using value_holder_type = typename std::conditional<
+      Extent == flatbuffers::dynamic_extent,
+      std::vector<std::remove_cv_t<Value>>,
+      std::array<std::remove_cv_t<Value>, Extent>>::type;
+
+ private:
+  value_holder_type value_holder_;
+
+ public:
+  bool load(handle src, bool convert) {
+    if (src.is_none()) {
+      // Use the default-constructed value (empty for dynamic extents, zeros
+      // otherwise).
+      return true;
+    }
+    if (::flatbuffers::pybind::MakeSpanFromObject<Value, Extent>(
+            value, src, /*throw_error=*/false)) {
+      return true;
+    }
+
+    if (!isinstance<sequence>(src)) {
+      throw value_error("Input must be a sequence.");
+    }
+    auto seq = reinterpret_borrow<sequence>(src);
+    if (Extent != flatbuffers::dynamic_extent && seq.size() != Extent) {
+      throw value_error(pybind11::str("Expected sequence size {} but got {}")
+                            .format(Extent, seq.size()));
+    }
+    internal::resize_maybe(&value_holder_, seq.size());
+    size_t index = 0;
+    for (const auto &it : seq) {
+      value_conv conv;
+      if (!conv.load(it, convert)) { return false; }
+      value_holder_[index++] = cast_op<Value &&>(std::move(conv));
+    }
+    value = SpanType(value_holder_.data(), value_holder_.size());
+    return true;
+  }
+
+  // flatbuffer generated accessors currently never return spans, so leave this
+  // unimplemented for now.
+  template<typename T>
+  static handle cast(T &&src, return_value_policy policy, handle parent) {
+    throw cast_error("Returning spans from flatbuffers is not yet supported.");
+  }
+
+  PYBIND11_TYPE_CASTER(SpanType, const_name("typing.Sequence[") +
+                                     value_conv::name + const_name("] | None"));
+
+  // flatbuffers::span is not default-constuctible for a fixed extent.
+  template<
+      std::size_t S = Extent,
+      typename std::enable_if<S != flatbuffers::dynamic_extent, int>::type = 0>
+  span_caster()
+      : value_holder_(), value(value_holder_.data(), value_holder_.size()) {}
+  template<
+      std::size_t S = Extent,
+      typename std::enable_if<S == flatbuffers::dynamic_extent, int>::type = 0>
+  span_caster() : value_holder_(), value() {}
+};
+
+template<typename Type, std::size_t Extent>
+struct type_caster<::flatbuffers::span<Type, Extent>>
+    : span_caster<::flatbuffers::span<Type, Extent>, Type, Extent> {};
+
+/// @brief Type caster to allow returning flatbuffers::String to Python.
+template<> struct type_caster<::flatbuffers::String> {
+  using value_conv = make_caster<std::string_view>;
+
+  bool load(handle src, bool convert) {
+    throw cast_error("Flatbuffer strings are not writeable.");
+    return false;
+  }
+
+  static handle cast(const ::flatbuffers::String &src,
+                     return_value_policy policy, handle parent) {
+    // NOTE: This always copies the string.
+    return pybind11::str(src.c_str(), src.size()).release();
+  }
+
+  PYBIND11_TYPE_CASTER(::flatbuffers::String, const_name("str"));
+};
+
+PYBIND11_NAMESPACE_END(detail)
+PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)
+
+#endif  // FLATBUFFERS_PYBIND_CASTERS_H_

--- a/pybind/include/flatbuffers/pybind/memory.h
+++ b/pybind/include/flatbuffers/pybind/memory.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024 Figure AI, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLATBUFFERS_PYBIND_MEMORY_H_
+#define FLATBUFFERS_PYBIND_MEMORY_H_
+
+#include <pybind11/pybind11.h>
+
+#include "flatbuffers/allocator.h"
+#include "flatbuffers/flatbuffer_builder.h"
+#include "flatbuffers/stl_emulation.h"
+
+namespace flatbuffers {
+namespace pybind {
+
+/// @brief Custom allocator for python which wraps a resizable bytearray.
+class ByteArrayAllocator : public Allocator {
+ public:
+  explicit ByteArrayAllocator(pybind11::bytearray &bytearray)
+      : bytearray_(bytearray) {}
+
+  uint8_t *allocate(size_t size) FLATBUFFERS_OVERRIDE {
+    if (size > bytearray_.size() &&
+        PyByteArray_Resize(bytearray_.ptr(), size) < 0) {
+      throw std::runtime_error("Failed to resize bytearray.");
+    }
+    FLATBUFFERS_ASSERT(PyByteArray_Size(bytearray_.ptr()) >= size);
+    return reinterpret_cast<uint8_t *>(PyByteArray_AS_STRING(bytearray_.ptr()));
+  }
+
+  void deallocate(uint8_t *p, size_t) FLATBUFFERS_OVERRIDE {
+    // Nothing to do; bytearray will be garbage collected by python.
+  }
+
+  uint8_t *reallocate_downward(uint8_t *old_p, size_t old_size, size_t new_size,
+                               size_t in_use_back,
+                               size_t in_use_front) FLATBUFFERS_OVERRIDE {
+    FLATBUFFERS_ASSERT(new_size > old_size);  // vector_downward only grows
+    uint8_t *resized_p = allocate(new_size);
+    // The front part of the buffer should be preserved from the resize
+    // operation. If the buffer grew by more than the in-use back part, we can
+    // memcpy; otherwise we must memmove to handle the potential overlap.
+    if ((new_size - old_size) >= in_use_back) {
+      memcpy(resized_p + new_size - in_use_back,
+             resized_p + old_size - in_use_back, in_use_back);
+    } else {
+      memmove(resized_p + new_size - in_use_back,
+              resized_p + old_size - in_use_back, in_use_back);
+    }
+    return resized_p;
+  }
+
+ private:
+  pybind11::bytearray bytearray_;
+};
+
+/// @brief Create a FlatBufferBuilder which is backed by the given bytearray.
+FlatBufferBuilder CreateFlatBufferBuilder(pybind11::bytearray &bytearray) {
+  size_t initial_size = bytearray.size();
+  return FlatBufferBuilder(initial_size, new ByteArrayAllocator(bytearray),
+                           /*own_allocator=*/true);
+}
+
+/// @brief Adapts the given FlatBufferBuilder as a memoryview.
+/// The backing memory allocation must outlive the memoryview.
+pybind11::memoryview AsMemoryView(FlatBufferBuilder &builder) {
+  return pybind11::memoryview::from_memory(builder.GetBufferPointer(),
+                                           builder.GetSize());
+}
+
+/// @brief Adapts an object implementing the buffer protocol into a span.
+template<typename T, std::size_t Extent = dynamic_extent,
+         typename std::enable_if<std::is_arithmetic<T>::value, int>::type = 0>
+bool MakeSpanFromBuffer(span<T, Extent> &result, const pybind11::buffer &buffer,
+                        bool throw_error = true) {
+  using FormatT = std::remove_cv_t<T>;
+  auto info = buffer.request(/*writable=*/!std::is_const<T>::value);
+  if (info.ndim != 1 || info.strides[0] != static_cast<ssize_t>(sizeof(T))) {
+    if (throw_error) {
+      throw pybind11::type_error(
+          "Buffer must be 1-dimensional and contiguous.");
+    }
+    return false;
+  }
+  if (!pybind11::detail::compare_buffer_info<FormatT>::compare(info) ||
+      static_cast<ssize_t>(sizeof(T)) != info.itemsize) {
+    if (throw_error) {
+      throw pybind11::type_error(
+          "Expected buffer format " +
+          pybind11::format_descriptor<FormatT>::format() + " but got " +
+          info.format);
+    }
+    return false;
+  }
+  if (Extent != dynamic_extent && info.size != Extent) {
+    if (throw_error) {
+      throw pybind11::value_error(
+          pybind11::str("Expected buffer size {} but got {}")
+              .format(Extent, info.size));
+    }
+    return false;
+  }
+  T *data = static_cast<T *>(info.ptr);
+  result = span<T, Extent>(data, info.size);
+  return true;
+}
+
+template<typename T, std::size_t Extent = dynamic_extent,
+         typename std::enable_if<!std::is_arithmetic<T>::value, int>::type = 0>
+bool MakeSpanFromBuffer(span<T, Extent> &result, const pybind11::buffer &buffer,
+                        bool throw_error = true) {
+  return false;
+}
+
+template<typename T, std::size_t Extent = dynamic_extent>
+bool MakeSpanFromObject(span<T, Extent> &result, pybind11::handle obj,
+                        bool throw_error = true) {
+  if (!PyObject_CheckBuffer(obj.ptr())) {
+    if (throw_error) {
+      throw pybind11::type_error(
+          "Object does not support the buffer protocol.");
+    }
+    return false;
+  }
+  return MakeSpanFromBuffer<T, Extent>(
+      result, pybind11::reinterpret_borrow<pybind11::buffer>(obj), throw_error);
+}
+
+}  // namespace pybind
+}  // namespace flatbuffers
+
+#endif  // FLATBUFFERS_PYBIND_MEMORY_H_

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -128,6 +128,8 @@ cc_library(
         "idl_gen_lobster.h",
         "idl_gen_php.cpp",
         "idl_gen_php.h",
+        "idl_gen_pybind.cpp",
+        "idl_gen_pybind.h",
         "idl_gen_python.cpp",
         "idl_gen_python.h",
         "idl_gen_rust.cpp",

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -254,6 +254,10 @@ const static FlatCOption flatc_options[] = {
   { "", "python-no-type-prefix-suffix", "",
     "Skip emission of Python functions that are prefixed with typenames" },
   { "", "python-typing", "", "Generate Python type annotations" },
+  { "", "pybind-include-filename-suffix", "",
+    "The suffix that is assumed for generated C++ headers that are included by "
+    "the pybind module. This is needed if the C++ headers are generated with a "
+    "different `--filename-suffix` than the pybind module." },
   { "", "ts-omit-entrypoint", "",
     "Omit emission of namespace entrypoint file" },
   { "", "file-names-only", "",
@@ -664,6 +668,9 @@ FlatCOptions FlatCompiler::ParseFromCommandLineArguments(int argc,
         opts.python_no_type_prefix_suffix = true;
       } else if (arg == "--python-typing") {
         opts.python_typing = true;
+      } else if (arg == "--pybind-include-filename-suffix") {
+        if (++argi >= argc) Error("missing value following: " + arg, true);
+        opts.pybind_include_filename_suffix = argv[argi];
       } else if (arg == "--ts-omit-entrypoint") {
         opts.ts_omit_entrypoint = true;
       } else if (arg == "--annotate-sparse-vectors") {

--- a/src/flatc_main.cpp
+++ b/src/flatc_main.cpp
@@ -34,6 +34,7 @@
 #include "idl_gen_kotlin.h"
 #include "idl_gen_lobster.h"
 #include "idl_gen_php.h"
+#include "idl_gen_pybind.h"
 #include "idl_gen_python.h"
 #include "idl_gen_rust.h"
 #include "idl_gen_swift.h"
@@ -144,6 +145,11 @@ int main(int argc, const char *argv[]) {
       flatbuffers::FlatCOption{ "", "nim", "",
                                 "Generate Nim files for tables/structs" },
       flatbuffers::NewNimBfbsGenerator(flatbuffers_version));
+
+  flatc.RegisterCodeGenerator(
+      flatbuffers::FlatCOption{ "", "pybind", "",
+                                "Generate pybind files for tables/structs" },
+      flatbuffers::NewPybindCodeGenerator());
 
   flatc.RegisterCodeGenerator(
       flatbuffers::FlatCOption{ "p", "python", "",

--- a/src/idl_gen_pybind.cpp
+++ b/src/idl_gen_pybind.cpp
@@ -1,0 +1,1260 @@
+/*
+ * Copyright 2024 Figure AI, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+TODO(michaelahn): Feature completion:
+- Include docstrings in py::doc.
+- (In)equality operators.
+- Vector __contains__, more sequence methods.
+- C++-specific flatbuffer features (native types).
+*/
+
+#include "idl_gen_pybind.h"
+
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "flatbuffers/code_generators.h"
+#include "flatbuffers/flatbuffers.h"
+#include "flatbuffers/flatc.h"
+#include "flatbuffers/idl.h"
+#include "flatbuffers/util.h"
+#include "idl_namer.h"
+
+namespace flatbuffers {
+namespace pybind {
+
+namespace {
+
+// TODO(michaelahn): Factor out keywords and share with cpp/python code generators.
+// Taken from idl_gen_cpp.cpp.
+const std::unordered_set<std::string> &CppKeywords() {
+  const auto *const kKeywords = new std::unordered_set<std::string>{
+    "alignas",
+    "alignof",
+    "and",
+    "and_eq",
+    "asm",
+    "atomic_cancel",
+    "atomic_commit",
+    "atomic_noexcept",
+    "auto",
+    "bitand",
+    "bitor",
+    "bool",
+    "break",
+    "case",
+    "catch",
+    "char",
+    "char16_t",
+    "char32_t",
+    "class",
+    "compl",
+    "concept",
+    "const",
+    "constexpr",
+    "const_cast",
+    "continue",
+    "co_await",
+    "co_return",
+    "co_yield",
+    "decltype",
+    "default",
+    "delete",
+    "do",
+    "double",
+    "dynamic_cast",
+    "else",
+    "enum",
+    "explicit",
+    "export",
+    "extern",
+    "false",
+    "float",
+    "for",
+    "friend",
+    "goto",
+    "if",
+    "import",
+    "inline",
+    "int",
+    "long",
+    "module",
+    "mutable",
+    "namespace",
+    "new",
+    "noexcept",
+    "not",
+    "not_eq",
+    "nullptr",
+    "operator",
+    "or",
+    "or_eq",
+    "private",
+    "protected",
+    "public",
+    "register",
+    "reinterpret_cast",
+    "requires",
+    "return",
+    "short",
+    "signed",
+    "sizeof",
+    "static",
+    "static_assert",
+    "static_cast",
+    "struct",
+    "switch",
+    "synchronized",
+    "template",
+    "this",
+    "thread_local",
+    "throw",
+    "true",
+    "try",
+    "typedef",
+    "typeid",
+    "typename",
+    "union",
+    "unsigned",
+    "using",
+    "virtual",
+    "void",
+    "volatile",
+    "wchar_t",
+    "while",
+    "xor",
+    "xor_eq",
+  };
+  return *kKeywords;
+}
+
+// Taken from idl_gen_python.cpp.
+const std::unordered_set<std::string> &PythonKeywords() {
+  const auto *const kKeywords = new std::unordered_set<std::string>{
+    "False",   "None",     "True",     "and",    "as",   "assert", "break",
+    "class",   "continue", "def",      "del",    "elif", "else",   "except",
+    "finally", "for",      "from",     "global", "if",   "import", "in",
+    "is",      "lambda",   "nonlocal", "not",    "or",   "pass",   "raise",
+    "return",  "try",      "while",    "with",   "yield"
+  };
+  return *kKeywords;
+}
+
+// Extension of IDLOptions for pybind-generator.
+struct IDLOptionsPybind : public IDLOptions {
+  explicit IDLOptionsPybind(const IDLOptions &opts) : IDLOptions(opts) {}
+};
+
+struct OpaqueTypeInfo {
+  std::set<std::string> declaration_code;
+  std::set<std::string> definition_code;
+};
+
+Namer::Config MakeCppConfig(const IDLOptionsPybind &opts,
+                            const std::string &path) {
+  Namer::Config config{
+    /*types=*/Case::kKeep,
+    /*constants=*/Case::kScreamingSnake,
+    /*methods=*/Case::kSnake,
+    /*functions=*/Case::kSnake,
+    /*fields=*/Case::kKeep,
+    /*variable=*/Case::kSnake,
+    /*variants=*/Case::kKeep,
+    /*enum_variant_seperator=*/"::",
+    /*escape_keywords=*/Namer::Config::Escape::BeforeConvertingCase,
+    /*namespaces=*/Case::kKeep,
+    /*namespace_seperator=*/"::",
+    /*object_prefix=*/"",
+    /*object_suffix=*/"T",
+    /*keyword_prefix=*/"",
+    /*keyword_suffix=*/"_",
+    /*filenames=*/Case::kKeep,
+    /*directories=*/Case::kKeep,
+    /*output_path=*/"",
+    /*filename_suffix=*/"",
+    /*filename_extension=*/".cpp"
+  };
+  config = WithFlagOptions(config, opts, path);
+  return config;
+}
+
+Namer::Config MakePythonConfig(const IDLOptionsPybind &opts,
+                               const std::string &path) {
+  Namer::Config config{
+    /*types=*/Case::kKeep,
+    /*constants=*/Case::kScreamingSnake,
+    /*methods=*/Case::kSnake,
+    /*functions=*/Case::kSnake,
+    /*fields=*/Case::kKeep,
+    /*variable=*/Case::kSnake,
+    /*variants=*/Case::kKeep,
+    /*enum_variant_seperator=*/".",
+    /*escape_keywords=*/Namer::Config::Escape::BeforeConvertingCase,
+    /*namespaces=*/Case::kKeep,
+    /*namespace_seperator=*/".",
+    /*object_prefix=*/"",
+    /*object_suffix=*/"T",
+    /*keyword_prefix=*/"",
+    /*keyword_suffix=*/"_",
+    /*filenames=*/Case::kKeep,
+    /*directories=*/Case::kKeep,
+    /*output_path=*/"",
+    /*filename_suffix=*/"",
+    /*filename_extension=*/".py"
+  };
+  config = WithFlagOptions(config, opts, path);
+  return config;
+}
+
+const std::string &Indent(int level = 1) {
+  static auto *kCache = new std::unordered_map<int, std::string>();
+  auto it = kCache->find(level);
+  if (it != kCache->end()) { return it->second; }
+  return kCache->emplace(level, std::string(level * 2, ' ')).first->second;
+}
+
+std::string StrJoin(const std::vector<std::string> &items, const char *sep) {
+  std::string result;
+  if (items.empty()) return result;
+  size_t size = 0;
+  for (const auto &item : items) { size += item.size(); }
+  size += strlen(sep) * (items.size() - 1);
+  result.reserve(size);
+  result += items[0];
+  for (size_t i = 1; i < items.size(); ++i) {
+    result += sep;
+    result += items[i];
+  }
+  return result;
+}
+
+std::string PathToPyModule(std::string path) {
+  std::replace(path.begin(), path.end(), '/', '.');
+  return path;
+}
+
+}  // namespace
+
+class PybindGenerator : public BaseGenerator {
+ public:
+  PybindGenerator(const Parser &parser, const std::string &path,
+                  const std::string &file_name, const IDLOptionsPybind &opts)
+      : BaseGenerator(parser, path, file_name, "" /* not used */,
+                      "::" /* not used */, "cpp"),
+        opts_(opts),
+        cpp_namer_(
+            MakeCppConfig(opts, path),
+            std::set<std::string>(CppKeywords().begin(), CppKeywords().end())),
+        // NOTE: FlagOptions will trample `filename_extension`, but this is
+        // unused (we only emit C++ code).
+        py_namer_(MakePythonConfig(opts, path),
+                  std::set<std::string>(PythonKeywords().begin(),
+                                        PythonKeywords().end())),
+        // Copied from idl_gen_cpp.cpp.
+        float_const_gen_("std::numeric_limits<double>::",
+                         "std::numeric_limits<float>::", "quiet_NaN()",
+                         "infinity()") {}
+
+  bool generate() {
+    code_.Clear();
+    code_ += "// " + std::string(FlatBuffersGeneratedWarning()) + "\n\n";
+
+    // Pybind includes.
+    code_ += "#include <pybind11/pybind11.h>";
+    code_ += "";
+
+    // Standard library dependencies.
+    code_ += "#include <optional>";
+    code_ += "#include <variant>";
+    code_ += "";
+
+    GenerateCppIncludeDeps();
+
+    code_ += "namespace py = pybind11;";
+    code_ += "";
+
+    auto opaque_types = GetOpaqueTypes();
+    // Generate opaque type declarations.
+    for (const auto &declaration : opaque_types.declaration_code) {
+      code_ += declaration;
+    }
+    if (!opaque_types.declaration_code.empty()) { code_ += ""; }
+
+    const std::string module_name = file_name_ + opts_.filename_suffix;
+    code_ += "PYBIND11_MODULE(" + module_name + ", m) {";
+
+    GeneratePythonImports();
+
+    // Generate empty class binding variables for each struct/tables, since
+    // their attribute bindings may reference each other.
+    for (const auto &struct_def : parser_.structs_.vec) {
+      if (!struct_def->generated) {
+        GenerateStructOrTableDeclaration(*struct_def);
+      }
+    }
+    code_ += "";
+
+    // Generate enum bindings.
+    for (const auto &enum_def : parser_.enums_.vec) {
+      if (enum_def->generated) continue;
+      GenerateEnum(*enum_def);
+    }
+
+    // Generate opaque type binding definitions.
+    for (const auto &definition : opaque_types.definition_code) {
+      code_ += Indent() + definition;
+    }
+    if (!opaque_types.definition_code.empty()) { code_ += ""; }
+
+    // Generate struct bindings.
+    for (const auto &struct_def : parser_.structs_.vec) {
+      if (struct_def->fixed && !struct_def->generated) {
+        GenerateStruct(*struct_def);
+      }
+    }
+    // Generate table bindings.
+    for (const auto &struct_def : parser_.structs_.vec) {
+      if (!struct_def->fixed && !struct_def->generated) {
+        GenerateTable(*struct_def);
+        if (opts_.generate_object_based_api) {
+          GenerateTableObjectApi(*struct_def);
+        }
+      }
+    }
+
+    code_ += "}";
+
+    const std::string file_path = GeneratedFileName(path_, file_name_, opts_);
+    const std::string final_code = code_.ToString();
+
+    return SaveFile(file_path.c_str(), final_code, false);
+  }
+
+ private:
+  void GenerateComment(const std::vector<std::string> &dc,
+                       const char *prefix = "") {
+    std::string text;
+    ::flatbuffers::GenComment(dc, &text, nullptr, prefix);
+    code_ += text + "\\";
+  }
+
+  std::vector<std::string> GetDependencyModuleNames() {
+    // Get the list of includes, sorted alphabetically as there should be no
+    // dependence on ordering.
+    std::vector<IncludedFile> included_files(parser_.GetIncludedFiles());
+    std::stable_sort(included_files.begin(), included_files.end());
+    std::vector<std::string> module_names;
+    module_names.reserve(included_files.size());
+
+    for (const IncludedFile &included_file : included_files) {
+      // Strip the .fbs extension, and optionally strip the path prefix if
+      // specified.
+      std::string name_without_ext = StripExtension(included_file.schema_name);
+      module_names.push_back(opts_.keep_prefix ? name_without_ext
+                                               : StripPath(name_without_ext));
+    }
+    return module_names;
+  }
+
+  void GenerateCppIncludeDeps() {
+    IDLOptions cpp_opts = opts_;
+    cpp_opts.filename_extension = "h";
+    if (!opts_.pybind_include_filename_suffix.empty()) {
+      cpp_opts.filename_suffix = opts_.pybind_include_filename_suffix;
+    }
+    const std::string file_path =
+        GeneratedFileName(path_, file_name_, cpp_opts);
+    code_ += "#include \"" + file_path + "\"";
+
+    for (const std::string &cpp_include : opts_.cpp_includes) {
+      code_ += "#include \"" + cpp_include + "\"";
+    }
+
+    if (opts_.include_dependence_headers) {
+      auto dependency_names = GetDependencyModuleNames();
+      for (const std::string &dependency_name : dependency_names) {
+        code_ +=
+            "#include \"" +
+            GeneratedFileName(opts_.include_prefix, dependency_name, cpp_opts) +
+            "\"";
+      }
+    }
+
+    // Add flatbuffer pybind libraries.
+    code_ += "#include \"flatbuffers/pybind/bind_array.h\"";
+    code_ += "#include \"flatbuffers/pybind/casters.h\"";
+    code_ += "#include \"flatbuffers/pybind/memory.h\"";
+
+    code_ += "";
+  }
+
+  void GeneratePythonImports() {
+    if (!opts_.include_dependence_headers) { return; }
+    auto dependency_names = GetDependencyModuleNames();
+    for (std::string dependency_name : dependency_names) {
+      if (opts_.pybind_include_filename_suffix.empty()) {
+        dependency_name += opts_.pybind_include_filename_suffix;
+      } else {
+        dependency_name += opts_.filename_suffix;
+      }
+      code_ += Indent() + "py::module::import(\"" +
+               PathToPyModule(dependency_name) + "\");";
+    }
+    if (!dependency_names.empty()) { code_ += ""; }
+  }
+
+  OpaqueTypeInfo GetOpaqueTypes() {
+    OpaqueTypeInfo info;
+    for (const auto *struct_def : parser_.structs_.vec) {
+      if (struct_def->generated) continue;
+      for (const auto *field : GetFieldDefs(*struct_def)) {
+        const auto &field_type = field->value.type;
+        if (!IsArray(field_type) && !IsVector(field_type)) { continue; }
+        const auto cpp_type = CppType(field_type);
+        const auto element_type = field_type.VectorType();
+        const auto pybind_name = PyBindingName(field_type);
+
+        if (IsScalar(element_type.base_type) && !element_type.enum_def) {
+          info.definition_code.insert(
+              "::flatbuffers::pybind::BindArrayArithmetic<" + cpp_type +
+              ">(m, \"" + pybind_name + "\");");
+        } else if (element_type.base_type == BASE_TYPE_STRUCT ||
+                   element_type.base_type == BASE_TYPE_STRING) {
+          info.definition_code.insert(
+              "::flatbuffers::pybind::BindArrayReadonly<" + cpp_type +
+              ">(m, \"" + pybind_name + "\");");
+        } else {
+          info.definition_code.insert(
+              "::flatbuffers::pybind::BindArrayReadwrite<" + cpp_type +
+              ">(m, \"" + pybind_name + "\");");
+        }
+
+        if (!struct_def->fixed && opts_.generate_object_based_api) {
+          const auto obj_cpp_type = CppType(field_type, /*object_api=*/true);
+          const auto obj_pybind_name =
+              PyBindingName(field_type, /*object_api=*/true);
+
+          info.declaration_code.insert("PYBIND11_MAKE_OPAQUE(" + obj_cpp_type +
+                                       ");");
+          if (IsScalar(element_type.base_type)) {
+            info.definition_code.insert(
+                "::flatbuffers::pybind::BindStdVectorArithmetic<" +
+                obj_cpp_type + ">(m, \"" + obj_pybind_name + "\");");
+          } else {
+            info.definition_code.insert(
+                "::flatbuffers::pybind::BindStdVector<" + obj_cpp_type +
+                ">(m, \"" + obj_pybind_name + "\");");
+          }
+        }
+      }
+    }
+    return info;
+  }
+
+  // Generates a pybind definition for the given enum.
+  void GenerateEnum(const EnumDef &def) {
+    GenerateComment(def.doc_comment);
+    code_ += Indent() + "py::enum_<" + cpp_namer_.NamespacedType(def) +
+             ">(m, \"" + py_namer_.Type(def) + "\")\\";
+
+    const std::string line_indent = "\n" + Indent(3);
+    for (const auto *ev : def.Vals()) {
+      GenerateComment(ev->doc_comment, line_indent.c_str());
+      code_ += line_indent + ".value(\"" + py_namer_.Variant(*ev) + "\", " +
+               CppEnumValueName(def, *ev) + ")\\";
+    }
+    code_ += ";\n";  // Extra new-line.
+  }
+
+  // Sets formatting variables for the given struct.
+  void SetCodeValuesStruct(const StructDef &def) {
+    code_.SetValue("BIND_VAR", cpp_namer_.Variable(def));
+    code_.SetValue("CPP_TYPE", cpp_namer_.NamespacedType(def));
+    code_.SetValue("PY_TYPE", py_namer_.Type(def));
+  }
+
+  // Sets formatting variables for the given table.
+  void SetCodeValuesTable(const StructDef &def) {
+    code_.SetValue("BIND_VAR", cpp_namer_.Variable(def));
+    code_.SetValue("CPP_TYPE", cpp_namer_.NamespacedType(def));
+    code_.SetValue("PY_TYPE", py_namer_.Type(def));
+  }
+
+  // Sets formatting variables for the given table's object API.
+  void SetCodeValuesTableObjectApi(const StructDef &def) {
+    const std::string obj_type_name =
+        CppObjectApiType(def, /*namespaced=*/false);
+    code_.SetValue("BIND_VAR", cpp_namer_.Variable(obj_type_name));
+    code_.SetValue("CPP_TYPE", CppObjectApiType(def));
+    code_.SetValue("PY_TYPE", py_namer_.Type(obj_type_name));
+  }
+
+  // Generates an initially empty class binding for a struct/table.
+  void GenerateStructOrTableDeclaration(const StructDef &def) {
+    if (def.fixed) {
+      SetCodeValuesStruct(def);
+    } else {
+      if (opts_.generate_object_based_api) {
+        SetCodeValuesTableObjectApi(def);
+        code_ += Indent() +
+                 "py::class_<{{CPP_TYPE}}> {{BIND_VAR}}(m, \"{{PY_TYPE}}\");";
+      }
+      SetCodeValuesTable(def);
+    }
+    code_ +=
+        Indent() + "py::class_<{{CPP_TYPE}}> {{BIND_VAR}}(m, \"{{PY_TYPE}}\");";
+  }
+
+  // Generates an internal property that marks that this is a pybind flatbuffer
+  // class.
+  // TODO(michael-ahn): This is better as a class property once supported by
+  // pybind.
+  void GenerateInternalPybindTypeMarker(int base_type) {
+    code_ += Indent() +
+             "{{BIND_VAR}}.def_property_readonly(\"_fbs_pybind_type\", "
+             "[](py::handle) -> int { return " +
+             NumToString(base_type) + "; });";
+  }
+
+  // Generates a pybind definition for a struct.
+  void GenerateStruct(const StructDef &def) {
+    SetCodeValuesStruct(def);
+    GenerateComment(def.doc_comment);
+    GenerateInternalPybindTypeMarker(BASE_TYPE_STRUCT);
+
+    // Default constructor.
+    code_ += Indent() + "{{BIND_VAR}}.def(py::init<>());";
+
+    auto field_defs = GetFieldDefs(def);
+
+    // Keyword args constructor.
+    if (field_defs.size() > 0) {
+      std::vector<std::string> arg_types, py_args;
+      arg_types.reserve(field_defs.size());
+      py_args.reserve(field_defs.size());
+      for (const auto *field : field_defs) {
+        arg_types.push_back(CppArgumentType(field->value.type));
+        py_args.push_back("py::arg(\"" + field->name +
+                          "\") = " + PyArgDefaultValue(*field));
+      }
+      code_ += Indent() + "{{BIND_VAR}}.def(";
+      code_ += Indent(3) + "py::init<" + StrJoin(arg_types, ", ") + ">(),";
+      code_ += Indent(3) + StrJoin(py_args, ", ") + ");";
+    }
+
+    // Generate accessor bindings.
+    for (const auto *field : field_defs) {
+      const auto &field_type = field->value.type;
+      code_.SetValue("CPP_FIELD", cpp_namer_.Field(*field));
+      code_.SetValue("PY_FIELD", py_namer_.Field(*field));
+
+      if (IsStruct(field_type)) {
+        code_ += Indent() + "{{BIND_VAR}}.def_property(";
+        code_ += Indent(3) + "\"{{PY_FIELD}}\",";
+        code_ += Indent(3) + "&{{CPP_TYPE}}::{{CPP_FIELD}},";
+        code_ += Indent(3) + "[]({{CPP_TYPE}} &self, " +
+                 CppArgumentType(field_type) + " value) {";
+        code_ += Indent(4) + "self.mutable_{{CPP_FIELD}}() = value;";
+        code_ += Indent(3) + "});";
+        continue;
+      }
+
+      if (IsArray(field_type)) {
+        code_ += Indent() +
+                 "{{BIND_VAR}}.def_property_readonly(\"{{PY_FIELD}}\", "
+                 "&{{CPP_TYPE}}::mutable_{{CPP_FIELD}});";
+        continue;
+      }
+
+      // POD types.
+      if (opts_.mutable_buffer) {
+        code_ += Indent() +
+                 "{{BIND_VAR}}.def_property(\"{{PY_FIELD}}\", "
+                 "&{{CPP_TYPE}}::{{CPP_FIELD}}, "
+                 "&{{CPP_TYPE}}::mutate_{{CPP_FIELD}});";
+      } else {
+        code_ += Indent() +
+                 "{{BIND_VAR}}.def_property_readonly(\"{{PY_FIELD}}\", "
+                 "&{{CPP_TYPE}}::{{CPP_FIELD}});";
+      }
+    }
+
+    // __repr__
+    GenerateReprBinding(field_defs);
+
+    code_ += "";
+  }
+
+  void GenerateTable(const StructDef &def) {
+    SetCodeValuesTable(def);
+    GenerateInternalPybindTypeMarker(BASE_TYPE_STRUCT);
+
+    auto field_defs = GetFieldDefs(def);
+
+    // Class methods to interpret a buffer.
+    code_ += Indent() +
+             "{{BIND_VAR}}.def_static(\"get_root\", [](py::buffer buffer, bool "
+             "verify_buffer) {";
+    code_ += Indent(3) + "::flatbuffers::span<const uint8_t> buffer_span;";
+    code_ += Indent(3) +
+             "::flatbuffers::pybind::MakeSpanFromObject(buffer_span, buffer, "
+             "/*throw_error=*/true);";
+    code_ += Indent(3) + "if (verify_buffer) {";
+    code_ += Indent(4) +
+             "flatbuffers::Verifier verifier(buffer_span.data(), "
+             "buffer_span.size());";
+    code_ += Indent(4) + "if (!verifier.VerifyBuffer<{{CPP_TYPE}}>(nullptr)) {";
+    code_ += Indent(5) +
+             "throw std::runtime_error(\"Invalid buffer for {{PY_TYPE}}\");";
+    code_ += Indent(4) + "}";
+    code_ += Indent(3) + "}";
+    code_ += Indent(3) +
+             "return flatbuffers::GetRoot<{{CPP_TYPE}}>(buffer_span.data());";
+    // Keep the buffer alive.
+    code_ += Indent() +
+             "}, py::arg(\"buffer\"), py::arg(\"verify_buffer\") = false, "
+             "py::keep_alive<0, 1>(), py::return_value_policy::reference);";
+
+    // Generate accessor bindings.
+    for (const auto *field : field_defs) {
+      const auto &field_type = field->value.type;
+      code_.SetValue("CPP_FIELD", cpp_namer_.Field(*field));
+      code_.SetValue("PY_FIELD", py_namer_.Field(*field));
+      code_.SetValue("CPP_FIELD_TYPE",
+                     CppType(field_type, /*object_api=*/true));
+
+      if (IsUnion(field_type)) {
+        const auto &enum_def = *field_type.enum_def;
+        code_.SetValue("UNION_VARIANT_TYPE", CppUnionVariantType(enum_def));
+        code_.SetValue("UNION_ENUM_TYPE", cpp_namer_.NamespacedType(enum_def));
+
+        code_ += Indent() + "{{BIND_VAR}}.def_property_readonly(";
+        code_ += Indent(3) + "\"{{PY_FIELD}}\",";
+        code_ +=
+            Indent(3) + "[]({{CPP_TYPE}} &self) -> {{UNION_VARIANT_TYPE}} {";
+        code_ += Indent(4) + "switch (self.{{CPP_FIELD}}_type()) {";
+        for (const auto *val : enum_def.Vals()) {
+          code_ += Indent(5) + "case " + CppEnumValueName(enum_def, *val) + ":";
+          if (val->union_type.base_type == BASE_TYPE_NONE) {
+            code_ += Indent(6) + "return std::nullopt;";
+          } else if (val->union_type.base_type == BASE_TYPE_STRUCT) {
+            code_ += Indent(6) + "return static_cast<" +
+                     CppType(val->union_type) +
+                     "*>(self.mutable_{{CPP_FIELD}}());";
+          }
+        }
+        code_ += Indent(5) + "default:";
+        code_ +=
+            Indent(6) + "throw std::runtime_error(\"Invalid variant type\");";
+        code_ += Indent(4) + "}";
+        code_ += Indent(3) + "}, py::return_value_policy::reference_internal);";
+        continue;
+      }
+
+      if (IsStruct(field_type) || IsTable(field_type) || IsString(field_type) ||
+          IsVector(field_type)) {
+        code_.SetValue("MUTABLE_PREFIX",
+                       opts_.mutable_buffer ? "mutable_" : "");
+        code_ += Indent() + "{{BIND_VAR}}.def_property_readonly(";
+        code_ += Indent(3) + "\"{{PY_FIELD}}\",";
+        code_ +=
+            Indent(3) +
+            "[]({{CPP_TYPE}} &self) { return "
+            "std::make_optional(self.{{MUTABLE_PREFIX}}{{CPP_FIELD}}()); });";
+        continue;
+      }
+
+      // POD types.
+      if (opts_.mutable_buffer) {
+        code_ += Indent() +
+                 "{{BIND_VAR}}.def_property(\"{{PY_FIELD}}\", "
+                 "&{{CPP_TYPE}}::{{CPP_FIELD}}, "
+                 "&{{CPP_TYPE}}::mutate_{{CPP_FIELD}});";
+      } else {
+        code_ += Indent() +
+                 "{{BIND_VAR}}.def_property_readonly(\"{{PY_FIELD}}\", "
+                 "&{{CPP_TYPE}}::{{CPP_FIELD}});";
+      }
+    }
+
+    // Unpacking.
+    if (opts_.generate_object_based_api) {
+      code_ += Indent() +
+               "{{BIND_VAR}}.def(\"unpack_to\", [](const {{CPP_TYPE}} &self, " +
+               CppObjectApiType(def) + " &o) {";
+      code_ += Indent(3) + "self.UnPackTo(&o);";
+      code_ += Indent() + "}, py::call_guard<py::gil_scoped_release>());";
+    }
+
+    // __repr__
+    GenerateReprBinding(field_defs);
+
+    code_ += "";
+  }
+
+  // Generates a pybind definition for a table's object API (i.e. T-type).
+  void GenerateTableObjectApi(const StructDef &def) {
+    SetCodeValuesTableObjectApi(def);
+    GenerateComment(def.doc_comment);
+    GenerateInternalPybindTypeMarker(BASE_TYPE_STRUCT);
+
+    // Default constructor.
+    code_ += Indent() + "{{BIND_VAR}}.def(py::init<>());";
+
+    auto field_defs = GetFieldDefs(def);
+
+    // Keyword args constructor.
+    if (!field_defs.empty()) {
+      std::vector<std::string> ctor_params, py_args;
+      ctor_params.reserve(field_defs.size());
+      py_args.reserve(field_defs.size());
+      for (const auto *field : field_defs) {
+        std::string argument_type = CppArgumentType(
+            field->value.type, /*object_api=*/true, /*optional=*/true);
+        ctor_params.push_back(argument_type + " " +
+                              cpp_namer_.Variable(field->name));
+        py_args.push_back("py::arg(\"" + py_namer_.Variable(field->name) +
+                          "\") = " + PyArgDefaultValue(*field));
+      }
+      code_ += Indent() + "{{BIND_VAR}}.def(";
+      code_ += Indent(3) + "py::init([](" + StrJoin(ctor_params, ", ") + ") {";
+      code_ += Indent(4) + CppObjectApiType(def) + " self;";
+      for (const auto *field : field_defs) {
+        const auto &field_type = field->value.type;
+        code_.SetValue("CPP_FIELD", cpp_namer_.Field(*field));
+        code_.SetValue("CPP_FIELD_TYPE",
+                       CppType(field_type, /*object_api=*/true));
+        code_.SetValue("CPP_FIELD_VALUE", cpp_namer_.Variable(field->name));
+
+        if (IsString(field_type)) {
+          code_ += Indent(4) +
+                   "self.{{CPP_FIELD}} = std::move({{CPP_FIELD_VALUE}});";
+          continue;
+        }
+
+        if (IsUnion(field_type)) {
+          code_ += Indent(4) + "if ({{CPP_FIELD_VALUE}}.has_value()) {";
+          code_ += Indent(5) +
+                   "std::visit([&self](auto *value) { "
+                   "self.{{CPP_FIELD}}.Set(*value); }, *{{CPP_FIELD_VALUE}});";
+          code_ += Indent(4) + "}";
+          continue;
+        }
+
+        if (IsStruct(field_type) || IsTable(field_type)) {
+          code_ += Indent(4) + "if ({{CPP_FIELD_VALUE}}.has_value()) {";
+          code_ +=
+              Indent(5) +
+              "self.{{CPP_FIELD}} = "
+              "std::make_unique<{{CPP_FIELD_TYPE}}>(**{{CPP_FIELD_VALUE}});";
+          code_ += Indent(4) + "}";
+          continue;
+        }
+
+        if (IsVector(field_type)) {
+          const auto element_type = field_type.VectorType();
+          if (IsTable(element_type)) {
+            code_ += Indent(4) +
+                     "self.{{CPP_FIELD}}.reserve({{CPP_FIELD_VALUE}}.size());";
+            code_ +=
+                Indent(4) + "for (const auto *value : {{CPP_FIELD_VALUE}}) {";
+            code_ += Indent(5) +
+                     "self.{{CPP_FIELD}}.emplace_back(std::make_unique<" +
+                     CppType(element_type, /*object_api=*/true) + ">(*value));";
+            code_ += Indent(4) + "}";
+          } else {
+            code_ += Indent(4) +
+                     "self.{{CPP_FIELD}}.assign({{CPP_FIELD_VALUE}}.begin(), "
+                     "{{CPP_FIELD_VALUE}}.end());";
+          }
+          continue;
+        }
+
+        // POD types.
+        code_ += Indent(4) + "self.{{CPP_FIELD}} = {{CPP_FIELD_VALUE}};";
+      }
+      code_ += Indent(4) + "return self;";
+      if (!py_args.empty()) {
+        code_ +=
+            Indent(3) + "}), py::kw_only(), " + StrJoin(py_args, ", ") + ");";
+      } else {
+        code_ += Indent(3) + "}));";
+      }
+    }
+
+    // Generate accessor bindings.
+    for (const auto *field : field_defs) {
+      const auto &field_type = field->value.type;
+      code_.SetValue("CPP_FIELD", cpp_namer_.Field(*field));
+      code_.SetValue("PY_FIELD", py_namer_.Field(*field));
+      code_.SetValue("CPP_FIELD_TYPE",
+                     CppType(field_type, /*object_api=*/true));
+
+      if (IsUnion(field_type)) {
+        const auto &enum_def = *field_type.enum_def;
+        code_.SetValue("UNION_VARIANT_TYPE",
+                       CppUnionVariantType(enum_def, /*object_api=*/true));
+        code_.SetValue("UNION_ENUM_TYPE", cpp_namer_.NamespacedType(enum_def));
+
+        code_ += Indent() + "{{BIND_VAR}}.def_property(";
+        code_ += Indent(3) + "\"{{PY_FIELD}}\",";
+        // Getter.
+        code_ +=
+            Indent(3) + "[]({{CPP_TYPE}} &self) -> {{UNION_VARIANT_TYPE}} {";
+        code_ += Indent(4) + "switch (self.{{CPP_FIELD}}.type) {";
+        for (const auto *val : enum_def.Vals()) {
+          code_ += Indent(5) + "case " + CppEnumValueName(enum_def, *val) + ":";
+          if (val->union_type.base_type == BASE_TYPE_NONE) {
+            code_ += Indent(6) + "return std::nullopt;";
+          } else if (val->union_type.base_type == BASE_TYPE_STRUCT) {
+            code_ += Indent(6) + "return self.{{CPP_FIELD}}.As" +
+                     cpp_namer_.Type(*val->union_type.struct_def) + "();";
+          }
+        }
+        code_ += Indent(5) + "default:";
+        code_ +=
+            Indent(6) + "throw std::runtime_error(\"Invalid variant type\");";
+        code_ += Indent(4) + "}";
+        // Setter.
+        code_ += Indent(3) +
+                 "}, []({{CPP_TYPE}} &self, {{UNION_VARIANT_TYPE}} value) {;";
+        code_ += Indent(4) + "if (value.has_value()) {";
+        code_ += Indent(5) +
+                 "std::visit([&self](auto *v) { "
+                 "self.{{CPP_FIELD}}.Set(*v); }, *value);";
+        code_ += Indent(4) + "} else {";
+        code_ += Indent(5) + "self.{{CPP_FIELD}}.Reset();";
+        code_ += Indent(4) + "}";
+        code_ += Indent(3) + "}, py::return_value_policy::reference_internal);";
+
+        code_ += Indent() + "{{BIND_VAR}}.def(";
+        code_ += Indent(3) + "\"set_{{PY_FIELD}}\",";
+        code_ += Indent(3) +
+                 "[]({{CPP_TYPE}} &self, {{UNION_ENUM_TYPE}} union_enum) "
+                 "-> {{UNION_VARIANT_TYPE}} {";
+        code_ += Indent(4) + "switch (union_enum) {";
+        for (const auto *val : enum_def.Vals()) {
+          code_ += Indent(5) + "case " + CppEnumValueName(enum_def, *val) + ":";
+          if (val->union_type.base_type == BASE_TYPE_NONE) {
+            code_ += Indent(6) + "self.{{CPP_FIELD}}.Reset();";
+            code_ += Indent(6) + "return std::nullopt;";
+          } else if (val->union_type.base_type == BASE_TYPE_STRUCT) {
+            const auto &union_struct_def = *val->union_type.struct_def;
+            code_ += Indent(6) + "self.{{CPP_FIELD}}.Set(" +
+                     CppObjectApiType(union_struct_def) + "());";
+            code_ += Indent(6) + "return self.{{CPP_FIELD}}.As" +
+                     cpp_namer_.Type(union_struct_def) + "();";
+          }
+        }
+        code_ += Indent(5) + "default:";
+        code_ +=
+            Indent(6) + "throw std::runtime_error(\"Invalid variant type\");";
+        code_ += Indent(4) + "}";
+        code_ += Indent(3) + "}, py::return_value_policy::reference_internal);";
+        continue;
+      }
+
+      if (IsStruct(field_type) || IsTable(field_type)) {
+        code_ += Indent() + "{{BIND_VAR}}.def_property(";
+        code_ += Indent(3) + "\"{{PY_FIELD}}\",";
+        code_ += Indent(3) +
+                 "[](const {{CPP_TYPE}} &self) -> "
+                 "std::optional<{{CPP_FIELD_TYPE}}*> {";
+        code_ +=
+            Indent(4) + "if (self.{{CPP_FIELD}} == nullptr) { return std::nullopt; }";
+        code_ += Indent(4) + "return self.{{CPP_FIELD}}.get();";
+        code_ += Indent(3) + "},";
+        code_ += Indent(3) +
+                 "[]({{CPP_TYPE}} &self, std::optional<const "
+                 "{{CPP_FIELD_TYPE}}*> value) {";
+        code_ += Indent(4) + "if (!value.has_value()) {";
+        code_ += Indent(5) + "self.{{CPP_FIELD}} = nullptr;";
+        code_ += Indent(4) + "} else if (self.{{CPP_FIELD}} == nullptr) {";
+        code_ += Indent(5) +
+                 "self.{{CPP_FIELD}} = "
+                 "std::make_unique<{{CPP_FIELD_TYPE}}>(**value);";
+        code_ += Indent(4) + "} else {";
+        code_ += Indent(5) + "*self.{{CPP_FIELD}} = **value;";
+        code_ += Indent(4) + "}";
+        code_ += Indent(3) + "});";
+
+        // `ensure_{name}` method, which instantiates the struct/table if it doesn't exist.
+        code_ += Indent() + "{{BIND_VAR}}.def(";
+        code_ += Indent(3) + "\"ensure_{{PY_FIELD}}\",";
+        code_ +=
+            Indent(3) + "[]({{CPP_TYPE}} &self) -> {{CPP_FIELD_TYPE}}* {";
+        code_ += Indent(4) + "if (self.{{CPP_FIELD}} == nullptr) {";
+        code_ += Indent(5) +
+                 "self.{{CPP_FIELD}} = std::make_unique<{{CPP_FIELD_TYPE}}>();";
+        code_ += Indent(4) + "}";
+        code_ += Indent(4) + "return self.{{CPP_FIELD}}.get();";
+        code_ += Indent(3) + "}, py::return_value_policy::reference_internal);";
+        continue;
+      }
+
+      if (IsVector(field_type)) {
+        code_ += Indent() +
+                 "{{BIND_VAR}}.def_readonly(\"{{PY_FIELD}}\", "
+                 "&{{CPP_TYPE}}::{{CPP_FIELD}});";
+        continue;
+      }
+
+      // POD types.
+      code_ += Indent() +
+               "{{BIND_VAR}}.def_readwrite(\"{{PY_FIELD}}\", "
+               "&{{CPP_TYPE}}::{{CPP_FIELD}});";
+    }
+
+    // Packing.
+    code_ += Indent() +
+             "{{BIND_VAR}}.def(\"pack\", [](const {{CPP_TYPE}} &self, "
+             "py::bytearray buffer) {";
+    code_ +=
+        Indent(3) +
+        "auto fbb = ::flatbuffers::pybind::CreateFlatBufferBuilder(buffer);";
+    code_ += Indent(3) + "fbb.Finish(" + cpp_namer_.NamespacedType(def) +
+             "::Pack(fbb, &self));";
+    code_ += Indent(3) + "return ::flatbuffers::pybind::AsMemoryView(fbb);";
+    // The memoryview keeps the bytearray buffer alive.
+    code_ += Indent() + "}, py::keep_alive<0, 2>());";
+
+    // __repr__
+    GenerateReprBinding(field_defs);
+
+    code_ += "";
+  }
+
+  // Generates "__repr__" for a struct/table with the given fields.
+  // Expects that {{PY_TYPE}} is already set.
+  void GenerateReprBinding(const std::vector<const FieldDef *> &field_defs) {
+    if (field_defs.empty()) {
+      code_ += Indent() +
+               "{{BIND_VAR}}.def(\"__repr__\", [](py::handle) { return "
+               "\"{{PY_TYPE}}()\"; });";
+      return;
+    }
+    code_ += Indent() + "{{BIND_VAR}}.def(\"__repr__\", [](py::handle self) {";
+    code_ += Indent(3) + "py::list items;";
+    for (const auto *field : field_defs) {
+      code_.SetValue("PY_FIELD", py_namer_.Field(*field));
+      code_ += Indent(3) +
+               "items.append(py::str(\"{{PY_FIELD}}=\") + "
+               "py::repr(self.attr(\"{{PY_FIELD}}\")));";
+    }
+    code_ += Indent(3) +
+             "return py::str(\"{{PY_TYPE}}({})\").format(py::str(\", "
+             "\").attr(\"join\")(items));";
+    code_ += Indent() + "});";
+  }
+
+  std::vector<const FieldDef *> GetFieldDefs(const StructDef &def) {
+    std::vector<const FieldDef *> field_defs;
+    field_defs.reserve(def.fields.vec.size());
+    for (const auto *field : def.fields.vec) {
+      if (field->deprecated) continue;
+      if (field->value.type.base_type == BASE_TYPE_UTYPE) continue;
+      field_defs.push_back(field);
+    }
+    return field_defs;
+  }
+
+  std::string CppType(const Type &type, bool object_api = false) const {
+    if (IsScalar(type.base_type)) {
+      if (type.enum_def) { return cpp_namer_.NamespacedType(*type.enum_def); }
+      return StringOf(type.base_type);
+    }
+    switch (type.base_type) {
+      case BASE_TYPE_STRING: {
+        if (object_api) { return "std::string"; }
+        return "::flatbuffers::String";
+      }
+      case BASE_TYPE_ARRAY: {
+        return "::flatbuffers::Array<" +
+               CppType(type.VectorType(), object_api) + ", " +
+               NumToString(type.fixed_length) + ">";
+      }
+      case BASE_TYPE_VECTOR64:
+      case BASE_TYPE_VECTOR: {
+        const auto element_type = type.VectorType();
+        if (object_api) {
+          if (IsScalar(element_type.base_type) || IsStruct(element_type) ||
+              IsString(element_type)) {
+            return "std::vector<" + CppType(type.VectorType(), object_api) +
+                   ">";
+          }
+          return "std::vector<" +
+                 CppPointerType(type.VectorType(), object_api) + ">";
+        }
+        if (IsScalar(element_type.base_type)) {
+          return "::flatbuffers::Vector<" + CppType(type.VectorType()) + ">";
+        }
+        if (IsStruct(element_type)) {
+          return "::flatbuffers::Vector<const " + CppType(type.VectorType()) +
+                 " *>";
+        }
+        return "::flatbuffers::Vector<" + CppPointerType(type.VectorType()) +
+               ">";
+      }
+      case BASE_TYPE_STRUCT: {
+        if (!type.struct_def->fixed && object_api) {
+          return CppObjectApiType(*type.struct_def);
+        }
+        return cpp_namer_.NamespacedType(*type.struct_def);
+      }
+      case BASE_TYPE_UNION:
+        // Fall-through.  // TODO(michael-ahn): Fixme.
+      default: {
+        return "void";
+      }
+    }
+  }
+
+  std::string CppArgumentType(const Type &type, bool object_api = false,
+                              bool optional = false) const {
+    if (IsArray(type)) {
+      return "::flatbuffers::span<const " +
+             CppType(type.VectorType(), object_api) + ", " +
+             NumToString(type.fixed_length) + ">";
+    }
+    if (IsVector(type)) {
+      const auto element_type = type.VectorType();
+      std::string element_type_str;
+      if (IsString(element_type)) {
+        element_type_str = "std::string";
+      } else {
+        element_type_str = CppType(element_type, object_api);
+      }
+      if (IsTable(element_type)) {
+        return "::flatbuffers::span<const " + element_type_str + "*>";
+      }
+      return "::flatbuffers::span<const " + element_type_str + ">";
+    }
+    if (IsString(type)) { return "std::string"; }
+    if (IsUnion(type)) {
+      return CppUnionVariantType(*type.enum_def, object_api);
+    }
+    std::string type_str = CppType(type, object_api);
+    if (IsScalar(type.base_type)) { return type_str; }
+    // NOTE: While a raw pointer argument type can take None (as nullptr),
+    // std::optional will generate the correct signature (`T | None`).
+    if (optional) { return "std::optional<const " + type_str + "*>"; }
+    return "const " + type_str + " &";
+  }
+
+  std::string CppObjectApiType(const StructDef &def,
+                               bool namespaced = true) const {
+    FLATBUFFERS_ASSERT(!def.fixed);
+    std::string type_name =
+        opts_.object_prefix + cpp_namer_.Type(def.name) + opts_.object_suffix;
+    if (namespaced) {
+      return cpp_namer_.Namespace(*def.defined_namespace) + "::" + type_name;
+    }
+    return type_name;
+  }
+
+  std::string CppUnionVariantType(const EnumDef &def,
+                                  bool object_api = false) const {
+    std::vector<std::string> variant_types;
+    variant_types.reserve(def.Vals().size());
+    for (const auto *ev : def.Vals()) {
+      if (ev->union_type.base_type == BASE_TYPE_NONE) { continue; }
+      variant_types.push_back(CppType(ev->union_type, object_api) + "*");
+    }
+    return "std::optional<std::variant<" + StrJoin(variant_types, ", ") + ">>";
+  }
+
+  const std::string &CppPointerType(const FieldDef *field) const {
+    auto attr = field ? field->attributes.Lookup("cpp_ptr_type") : nullptr;
+    if (attr == nullptr || attr->constant == "default_ptr_type") {
+      return opts_.cpp_object_api_pointer_type;
+    }
+    return attr->constant;
+  }
+
+  std::string CppPointerType(const Type &type, bool object_api = false,
+                             const FieldDef *field = nullptr) const {
+    const auto base_type = CppType(type, object_api);
+    if (!object_api && (IsTable(type) || IsString(type))) {
+      return "::flatbuffers::Offset<" + base_type + ">";
+    }
+    const auto &ptr_type = CppPointerType(field);
+    if (ptr_type == "naked") { return base_type + " *"; }
+    return ptr_type + "<" + base_type + ">";
+  }
+
+  std::string CppEnumValueName(const EnumDef &def, const EnumVal &val,
+                               bool namespaced = true) const {
+    std::string value_name;
+    if (opts_.scoped_enums) {
+      value_name = cpp_namer_.Type(def) + "::" + cpp_namer_.Variant(val);
+    } else if (opts_.prefixed_enums) {
+      value_name = cpp_namer_.Type(def) + "_" + cpp_namer_.Variant(val);
+    } else {
+      value_name = cpp_namer_.Variant(val);
+    }
+    if (namespaced) {
+      return cpp_namer_.Namespace(*def.defined_namespace) + "::" + value_name;
+    }
+    return value_name;
+  }
+
+  std::string PyArgDefaultValue(const FieldDef &field) const {
+    auto *native_default = field.attributes.Lookup("native_default");
+    if (native_default != nullptr) { return native_default->constant; }
+
+    const auto &field_type = field.value.type;
+    if (IsScalar(field_type.base_type)) {
+      if (field.IsScalarOptional()) { return "py::none()"; }
+      if (IsEnum(field_type)) {
+        auto *ev = field_type.enum_def->FindByValue(field.value.constant);
+        if (ev != nullptr) {
+          return CppEnumValueName(*field_type.enum_def, *ev);
+        } else {
+          return "static_cast<" + CppType(field_type) + ">(" +
+                 field.value.constant + ")";
+        }
+      }
+      if (IsFloat(field_type.base_type)) {
+        return float_const_gen_.GenFloatConstant(field);
+      }
+      // TODO(michael-ahn): Consider reusing NumToStringCpp.
+      return field.value.constant;
+    }
+    if (IsStruct(field_type)) { return CppType(field_type) + "()"; }
+    if (IsString(field_type)) { return "\"\""; }
+    return "py::none()";
+  }
+
+  std::string PyBindingName(const Type &type, bool object_api = false) const {
+    if (IsScalar(type.base_type)) {
+      if (type.enum_def) { return py_namer_.Type(*type.enum_def); }
+      std::string scalar_type_str = StringOf(type.base_type);
+      // Strip a "_t" suffix.
+      if (scalar_type_str.rfind("_t") == scalar_type_str.size() - 2) {
+        scalar_type_str = scalar_type_str.substr(0, scalar_type_str.size() - 2);
+      }
+      return ConvertCase(py_namer_.EscapeKeyword(scalar_type_str),
+                         Case::kUpperCamel, Case::kSnake);
+    }
+    switch (type.base_type) {
+      case BASE_TYPE_STRING: {
+        return "Str";
+      }
+      case BASE_TYPE_ARRAY: {
+        return PyBindingName(type.VectorType(), object_api) + "Array" +
+               NumToString(type.fixed_length);
+      }
+      case BASE_TYPE_VECTOR64:
+      case BASE_TYPE_VECTOR: {
+        std::string vector_type = object_api ? "StdVector" : "FbsVector";
+        return PyBindingName(type.VectorType(), object_api) +
+               (object_api ? "StdVector" : "FbsVector");
+      }
+      case BASE_TYPE_STRUCT: {
+        if (!type.struct_def->fixed && object_api) {
+          return opts_.object_prefix + py_namer_.Type(*type.struct_def) +
+                 opts_.object_suffix;
+        }
+        return py_namer_.Type(*type.struct_def);
+      }
+      case BASE_TYPE_UNION: {
+        return py_namer_.Type(*type.enum_def);
+      }
+      default: {
+        return "Unknown";
+      }
+    }
+  }
+
+  const IDLOptionsPybind opts_;
+  const IdlNamer cpp_namer_;
+  const IdlNamer py_namer_;
+  const TypedFloatConstantGenerator float_const_gen_;
+  CodeWriter code_;
+
+  std::unordered_set<std::string> keywords_;
+};
+
+}  // namespace pybind
+
+static bool GeneratePybind(const Parser &parser, const std::string &path,
+                           const std::string &file_name) {
+  pybind::IDLOptionsPybind opts(parser.opts);
+  pybind::PybindGenerator generator(parser, path, file_name, opts);
+
+  return generator.generate();
+}
+
+namespace {
+
+class PybindCodeGenerator : public CodeGenerator {
+ public:
+  Status GenerateCode(const Parser &parser, const std::string &path,
+                      const std::string &filename) override {
+    if (!GeneratePybind(parser, path, filename)) { return Status::ERROR; }
+    return Status::OK;
+  }
+
+  Status GenerateCode(const uint8_t *, int64_t,
+                      const CodeGenOptions &) override {
+    return Status::NOT_IMPLEMENTED;
+  }
+
+  Status GenerateMakeRule(const Parser &parser, const std::string &path,
+                          const std::string &filename,
+                          std::string &output) override {
+    (void)parser;
+    (void)path;
+    (void)filename;
+    (void)output;
+    return Status::NOT_IMPLEMENTED;
+  }
+
+  Status GenerateGrpcCode(const Parser &parser, const std::string &path,
+                          const std::string &filename) override {
+    (void)parser;
+    (void)path;
+    (void)filename;
+    return Status::NOT_IMPLEMENTED;
+  }
+
+  Status GenerateRootFile(const Parser &parser,
+                          const std::string &path) override {
+    (void)parser;
+    (void)path;
+    return Status::NOT_IMPLEMENTED;
+  }
+
+  bool IsSchemaOnly() const override { return true; }
+
+  bool SupportsBfbsGeneration() const override { return false; }
+  bool SupportsRootFileGeneration() const override { return false; }
+
+  IDLOptions::Language Language() const override { return IDLOptions::kPybind; }
+
+  std::string LanguageName() const override { return "Pybind"; }
+};
+
+}  // namespace
+
+std::unique_ptr<CodeGenerator> NewPybindCodeGenerator() {
+  return std::unique_ptr<PybindCodeGenerator>(new PybindCodeGenerator());
+}
+
+}  // namespace flatbuffers

--- a/src/idl_gen_pybind.h
+++ b/src/idl_gen_pybind.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Figure AI, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLATBUFFERS_IDL_GEN_PYBIND_H_
+#define FLATBUFFERS_IDL_GEN_PYBIND_H_
+
+#include "flatbuffers/code_generator.h"
+
+namespace flatbuffers {
+
+// Constructs a new pybind11 code generator.
+std::unique_ptr<CodeGenerator> NewPybindCodeGenerator();
+
+}  // namespace flatbuffers
+
+#endif  // FLATBUFFERS_IDL_GEN_PYBIND_H_

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -2703,14 +2703,15 @@ bool Parser::SupportsAdvancedUnionFeatures() const {
           ~(IDLOptions::kCpp | IDLOptions::kTs | IDLOptions::kPhp |
             IDLOptions::kJava | IDLOptions::kCSharp | IDLOptions::kKotlin |
             IDLOptions::kBinary | IDLOptions::kSwift | IDLOptions::kNim |
-            IDLOptions::kJson | IDLOptions::kKotlinKmp)) == 0;
+            IDLOptions::kJson | IDLOptions::kKotlinKmp | IDLOptions::kPybind)) == 0;
 }
 
 bool Parser::SupportsAdvancedArrayFeatures() const {
   return (opts.lang_to_generate &
           ~(IDLOptions::kCpp | IDLOptions::kPython | IDLOptions::kJava |
             IDLOptions::kCSharp | IDLOptions::kJsonSchema | IDLOptions::kJson |
-            IDLOptions::kBinary | IDLOptions::kRust | IDLOptions::kTs)) == 0;
+            IDLOptions::kBinary | IDLOptions::kRust | IDLOptions::kTs |
+            IDLOptions::kPybind)) == 0;
 }
 
 bool Parser::Supports64BitOffsets() const {

--- a/tests/PybindTest.sh
+++ b/tests/PybindTest.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright 2024 Figure AI, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+pushd "$(dirname $0)" >/dev/null
+test_dir="$(pwd)"
+
+# Possible build output paths.
+BUILD_OUTPUT_PATHS=("../build" "..")
+for build_output_path in "${BUILD_OUTPUT_PATHS[@]}"; do
+  if [ -f "${build_output_path}/flatc" ]; then
+    break
+  fi
+done
+
+PYTHONPATH="${build_output_path}" python3 pybind_test.py

--- a/tests/pybind_test.py
+++ b/tests/pybind_test.py
@@ -1,0 +1,102 @@
+
+
+import unittest
+
+import monster_generated
+
+import numpy as np
+
+
+class MonsterGeneratedTest(unittest.TestCase):
+
+    def test_vec3_simple(self):
+        v = monster_generated.Vec3()
+        self.assertEqual(v.x, 0.0)
+        self.assertEqual(v.y, 0.0)
+        self.assertEqual(v.z, 0.0)
+
+        v.x = 1.5
+        v.y = 2.5
+        v.z = 3.5
+        self.assertAlmostEqual(v.x, 1.5)
+        self.assertAlmostEqual(v.y, 2.5)
+        self.assertAlmostEqual(v.z, 3.5)
+
+        w = monster_generated.Vec3(x=-1.1, y=-2.2, z=-3.3)
+        self.assertAlmostEqual(w.x, -1.1)
+        self.assertAlmostEqual(w.y, -2.2)
+        self.assertAlmostEqual(w.z, -3.3)
+
+    def test_weapon_simple(self):
+        weapon = monster_generated.WeaponT()
+        self.assertEqual(weapon.name, "")
+        self.assertEqual(weapon.damage, 0)
+
+        weapon.name = "sword"
+        weapon.damage = 10
+        self.assertEqual(weapon.name, "sword")
+        self.assertEqual(weapon.damage, 10)
+
+        weapon.damage += 5
+        self.assertEqual(weapon.damage, 15)
+
+        bow = monster_generated.WeaponT(name="bow", damage=50)
+        self.assertEqual(bow.name, "bow")
+        self.assertEqual(bow.damage, 50)
+
+    def test_monster_simple(self):
+        m0 = monster_generated.MonsterT()
+        self.assertIsNone(m0.pos)
+        self.assertEqual(m0.mana, 150)
+        self.assertEqual(m0.hp, 100)
+        self.assertEqual(m0.name, "")
+        self.assertSequenceEqual(m0.inventory, [])
+        self.assertEqual(m0.color, monster_generated.Color.Blue)
+        self.assertSequenceEqual(m0.weapons, [])
+        self.assertIsNone(m0.equipped)
+        self.assertSequenceEqual(m0.path, [])
+
+    def test_monster_numpy(self):
+        m0 = monster_generated.MonsterT(pos=monster_generated.Vec3(x=1.1, y=2.2, z=3.3),
+                                        name="wizard", inventory=[1, 2, 0])
+        np.testing.assert_array_equal(m0.inventory, [1, 2, 0])
+        m0.inventory.numpy()[2] += 3
+        np.testing.assert_array_equal(m0.inventory, [1, 2, 3])
+        data = m0.pack(bytearray())
+
+        m1 = monster_generated.Monster.get_root(data)
+        buf = np.array(m1.inventory, copy=False)
+        self.assertEqual(buf.shape, (3,))
+        self.assertEqual(buf.dtype, np.uint8)
+
+        buf[:] += np.array([1, 3, 5], dtype=np.uint8)
+        np.testing.assert_array_equal(m1.inventory, [2, 5, 8])
+
+        buf_np = m1.inventory.numpy()
+        self.assertEqual(buf_np.shape, (3,))
+        self.assertEqual(buf_np.dtype, np.uint8)
+        np.testing.assert_array_equal(buf_np, [2, 5, 8])
+
+    def test_monster_pack_unpack(self):
+        m0 = monster_generated.MonsterT(pos=monster_generated.Vec3(x=1.1, y=2.2, z=3.3),
+                                        name="wizard", inventory=[1, 2, 3])
+        data = m0.pack(bytearray())
+
+        m1 = monster_generated.Monster.get_root(data)
+        self.assertAlmostEqual(m1.pos.x, 1.1)
+        self.assertAlmostEqual(m1.pos.y, 2.2)
+        self.assertAlmostEqual(m1.pos.z, 3.3)
+        self.assertEqual(m1.name, "wizard")
+        self.assertSequenceEqual(m1.inventory, [1, 2, 3])
+
+        m2 = monster_generated.MonsterT()
+        m1.unpack_to(m2)
+        self.assertEqual(m0.pos.x, m2.pos.x)
+        self.assertEqual(m0.pos.y, m2.pos.y)
+        self.assertEqual(m0.pos.z, m2.pos.z)
+        self.assertEqual(m0.name, m2.name)
+        np.testing.assert_array_equal(m0.inventory.numpy(), m2.inventory.numpy())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds support for flatbuffers to generate [pybind](https://github.com/pybind/pybind11) code, as an alternative to the python code generation.

pybind code has a number of advantages over python:
- Seamless interop with C++ for codebases that use heavily use both: we can easily pass a flatbuffer type between C++ and Python without copying memory (i.e. by reference, with proper lifetime management), or transfer ownership
- Many operations are much faster, or at least as fast python. In particular, packing (object API type to non-object type) is >20x faster from internal benchmarks. Most operations do not allocate or support a usage method that modifies a message in-place (e.g. upacking to an object API type). Packing supports reusing an existing buffer.

Misc:
- This fixes `::flatbuffers::span` not being assignable.