### PR TITLE
Fix heap-use-after-free in Python --gen-object-api on deprecated union members.

### DIFF
--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -2850,14 +2850,19 @@ class PythonGenerator : public BaseGenerator {
                                std::string *code_ptr) const {
     auto &code = *code_ptr;
     const auto union_type = namer_.Type(enum_def);
-    auto modified_ev = ev;
+    // Compute the variant name as a string instead of copying the EnumVal.
+    // Copying EnumVal shallow-copies its `attributes` SymbolTable<Value>,
+    // whose destructor would free Value* pointers still owned by the
+    // parser's original EnumVal -- a use-after-free at Parser teardown
+    // for any union member with non-empty attributes (e.g. deprecated).
+    std::string variant_name = namer_.Variant(ev);
     // If we are a single file mode then we need to create a object name in the
     // local scope without the namespace.
     // TODO(ENG-7570) Split on .s before they are converted to _, or add
     // explicit check against _ in the table name during early validation.
     if (const auto last_underscore = ev.name.find_last_of('_');
         parser_.opts.one_file && last_underscore != ev.name.npos) {
-      modified_ev.name = ev.name.substr(last_underscore + 1);
+      variant_name = namer_.Variant(ev.name.substr(last_underscore + 1));
     }
     auto field_type = namer_.ObjectType(*ev.union_type.struct_def);
 
@@ -2869,7 +2874,7 @@ class PythonGenerator : public BaseGenerator {
       field_type = package_reference + "." + field_type;
     }
 
-    code += GenIndents(2) + "obj = " + namer_.Variant(modified_ev) + "()";
+    code += GenIndents(2) + "obj = " + variant_name + "()";
     code += GenIndents(2) + "obj.init(table.Bytes, table.Pos)";
     code += GenIndents(2) + "return obj";
   }


### PR DESCRIPTION
Fix heap-use-after-free in Python --gen-object-api on deprecated union members.

GenUnionCreatorForTable does `auto modified_ev = ev;` to make a local EnumVal
copy whose `name` field can be mutated for single-file mode. The implicit
copy-constructor shallow-copies EnumVal::attributes (a SymbolTable<Value>
that owns its Value* via raw pointers and frees them in its destructor).
When `modified_ev` goes out of scope its SymbolTable destructor frees those
pointers; the original ev (owned by the Parser) is left dangling and the
attributes are freed again at Parser teardown, manifesting as a
heap-use-after-free / double-free / std::string SSO stomp depending on
heap layout.

For non-deprecated union members ev.attributes is empty so the bug is
invisible; for deprecated union members the "deprecated" attribute Value
sits in the table and the UAF fires reliably under --python --gen-object-api.

Fix: don't copy the EnumVal. namer_.Variant has a std::string overload, so
compute the variant name directly as a string.