### PR TITLE
Tighten up type hints in python generated code

### DIFF
--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -2028,9 +2028,14 @@ class PythonGenerator : public BaseGenerator {
 
       const auto default_value = GetDefaultValue(field);
       // Wrties the init statement.
+      if (default_value == "None" &&
+          field_type.compare(0, 9, "Optional[") != 0) {
+        import_typing_list.insert("Optional");
+        field_type = "Optional[" + field_type + "]";
+      }
       const auto field_field = namer_.Field(field);
-      code += GenIndents(2) + "self." + field_field + " = " + default_value +
-              "  # type: " + field_type;
+      code += GenIndents(2) + "self." + field_field + ": " + field_type +
+              " = " + default_value;
     }
 
     // Writes __init__ method.
@@ -2085,9 +2090,11 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
     const auto struct_var = namer_.Variable(struct_def);
     const auto struct_type = namer_.Type(struct_def);
+    const auto struct_object = namer_.ObjectType(struct_def);
 
     code += GenIndents(1) + "@classmethod";
-    code += GenIndents(1) + "def init_from_buf(cls, buf, pos):";
+    code += GenIndents(1) + "def init_from_buf(cls, buf, pos) -> '" +
+            struct_object + "':";
     code += GenIndents(2) + struct_var + " = " + struct_type + "()";
     code += GenIndents(2) + struct_var + ".init(buf, pos)";
     code += GenIndents(2) + "return cls.init_from_obj(" + struct_var + ")";
@@ -2099,9 +2106,11 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
     const auto struct_var = namer_.Variable(struct_def);
     const auto struct_type = namer_.Type(struct_def);
+    const auto struct_object = namer_.ObjectType(struct_def);
 
     code += GenIndents(1) + "@classmethod";
-    code += GenIndents(1) + "def init_from_packed_buf(cls, buf, pos=0):";
+    code += GenIndents(1) + "def init_from_packed_buf(cls, buf, pos=0) -> '" +
+            struct_object + "':";
     code += GenIndents(2) +
             "n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)";
     code += GenIndents(2) + "return cls.init_from_buf(buf, pos+n)";
@@ -2115,7 +2124,8 @@ class PythonGenerator : public BaseGenerator {
     const auto struct_object = namer_.ObjectType(struct_def);
 
     code += GenIndents(1) + "@classmethod";
-    code += GenIndents(1) + "def init_from_obj(cls, " + struct_var + "):";
+    code += GenIndents(1) + "def init_from_obj(cls, " + struct_var + ") -> '" +
+            struct_object + "':";
     code += GenIndents(2) + "x = " + struct_object + "()";
     code += GenIndents(2) + "x.unpack(" + struct_var + ")";
     code += GenIndents(2) + "return x";

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -757,8 +757,8 @@ class PythonGenerator : public BaseGenerator {
 
     GenReceiver(struct_def, code_ptr);
     code += namer_.Method(field);
-    code += "(self): \n";
-    code += Indent + " return " + getter;
+    code += "(self):\n";
+    code += Indent + Indent + "return " + getter;
   }
 
   // Get the value of a table's scalar.
@@ -1113,20 +1113,38 @@ class PythonGenerator : public BaseGenerator {
 
     const ImportMapEntry import_entry = { GenPackageReference(field.value.type),
                                           TypeName(field) };
+    const bool is_vector_of_struct =
+        field.value.type.base_type == BASE_TYPE_VECTOR &&
+        vectortype.base_type == BASE_TYPE_STRUCT;
 
     if (parser_.opts.python_typing) {
-      std::string return_type = "Any";
-      if (vectortype.base_type == BASE_TYPE_STRUCT) {
-        return_type = ReturnType(struct_def, field) + " | None";
+      code += "(self) -> Generator[" +
+              VectorElementPythonType(struct_def, field) + ", None, None]:";
+      if (!parser_.opts.one_file &&
+          (vectortype.base_type == BASE_TYPE_STRUCT || IsEnum(vectortype))) {
+        imports.insert(import_entry);
       }
-      code += "(self) -> Generator[" + return_type + ", None, None]:";
-      imports.insert(ImportMapEntry{ "typing", "Optional" });
-      if (!parser_.opts.one_file) { imports.insert(import_entry); }
     } else {
       code += "(self):";
     }
-    code += GenIndents(2) + "return (self." + name +
-            "_get(i) for i in range(self." + name + "_length()))\n\n";
+
+    if (is_vector_of_struct) {
+      code += OffsetPrefix(field, false);
+      code += GenIndents(3) + "x = self._tab.Vector(o)";
+      code += GenIndents(3) + "for i in range(self._tab.VectorLen(o)):";
+      code += GenIndents(4) +
+              "y = x + flatbuffers.number_types.UOffsetTFlags.py_type(i) * " +
+              NumToString(InlineSize(vectortype));
+      if (!vectortype.struct_def->fixed) {
+        code += GenIndents(4) + "y = self._tab.Indirect(y)";
+      }
+      code += GenIndents(4) + "obj = " + TypeName(field) + "()";
+      code += GenIndents(4) + "obj.init(self._tab.Bytes, y)";
+      code += GenIndents(4) + "yield obj\n\n";
+    } else {
+      code += GenIndents(2) + "return (self." + name +
+              "_get(i) for i in range(self." + name + "_length()))\n\n";
+    }
   }
 
   // Get the value of a vector's struct member.
@@ -1180,7 +1198,8 @@ class PythonGenerator : public BaseGenerator {
     GenReceiver(struct_def, code_ptr);
     code += namer_.Method(field);
     if (parser_.opts.python_typing) {
-      code += "_get(self, j: int)";
+      code +=
+          "_get(self, j: int) -> " + VectorElementPythonType(struct_def, field);
     } else {
       code += "_get(self, j)";
     }
@@ -1193,17 +1212,27 @@ class PythonGenerator : public BaseGenerator {
     getter += "a + flatbuffers.number_types.UOffsetTFlags.py_type(j * ";
     getter += NumToString(InlineSize(vectortype)) + "))";
 
-    if (IsEnum(field.value.type.VectorType())) {
-      getter = field.value.type.enum_def->name + "(" + getter + ")";
+    if (IsString(vectortype)) {
+      getter += ".decode('utf-8')";
+    } else if (IsEnum(vectortype)) {
+      getter = vectortype.enum_def->name + "(" + getter + ")";
     }
     code += "return " + getter + "\n";
 
-    if (IsString(vectortype)) {
-      code += Indent + Indent + "return \"\"\n";
+    // If empty, return the zero value for the type.
+    code += Indent + Indent + "return ";
+    if (IsEnum(vectortype)) {
+      code += vectortype.enum_def->name + "(0)";
+    } else if (IsString(vectortype)) {
+      code += "\"\"";
+    } else if (IsBool(vectortype.base_type)) {
+      code += "False";
+    } else if (IsFloat(vectortype.base_type)) {
+      code += "0.0";
     } else {
-      code += Indent + Indent + "return 0\n";
+      code += "0";
     }
-    code += "\n";
+    code += "\n\n";
   }
 
   // Returns a non-struct vector as a numpy array. Much faster
@@ -1827,6 +1856,20 @@ class PythonGenerator : public BaseGenerator {
     }
   }
 
+  std::string VectorElementPythonType(const StructDef &struct_def,
+                                      const FieldDef &field) const {
+    const Type vectortype = field.value.type.VectorType();
+    if (IsEnum(vectortype)) { return vectortype.enum_def->name; }
+    if (vectortype.base_type == BASE_TYPE_STRUCT) {
+      return ReturnType(struct_def, field);
+    }
+    if (vectortype.base_type == BASE_TYPE_STRING ||
+        IsScalar(vectortype.base_type)) {
+      return GetBasePythonTypeForScalarAndString(vectortype.base_type);
+    }
+    return "Any";
+  }
+
   std::string GetDefaultValue(const FieldDef &field) const {
     BaseType base_type = field.value.type.base_type;
     if (IsVector(field.value.type)) {
@@ -2026,10 +2069,9 @@ class PythonGenerator : public BaseGenerator {
         }
       }
 
-      const auto default_value = GetDefaultValue(field);
       // Wrties the init statement.
-      if (default_value == "None" &&
-          field_type.compare(0, 9, "Optional[") != 0) {
+      const auto default_value = GetDefaultValue(field);
+      if (default_value == "None" && !field_type.starts_with("Optional[")) {
         import_typing_list.insert("Optional");
         field_type = "Optional[" + field_type + "]";
       }
@@ -2182,7 +2224,7 @@ class PythonGenerator : public BaseGenerator {
 
     code += GenIndents(1) + "def __repr__(self) -> str:";
     code += GenIndents(2) + "if not hasattr(self, '_tab'):";
-    code += GenIndents(3) + " return '" + struct_object + "()'";
+    code += GenIndents(3) + "return '" + struct_object + "()'";
     code += GenIndents(2) + "return f'" + struct_object + "(";
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {


### PR DESCRIPTION
- Vectors in table types:
  - Generator should not return None. It should send a Stop Iteration exception. This is weird but that's how python generators work. The values of doing this is we can make the type hint of the yield type non-optional (no Nones).
  - Same goes for element getter functions of vectors. They get a non-None type now.
  - For absent fields we now fallback to the correct default for the type.
  - In vector of strings, we were not returning string. We were returning raw bytes. This seemed wrong. Now I call decode in the getter similar getter functions for individual string fields. **The change is a breaking change** and I had to make changes in the code to make everything work. I'm relying on Ty type checking + tests + Claude.
- T-types:
  - Only numbers and booleans had proper type hints. Everything else was unknown because they were being set to None or []. Now they have proper type hints. This actually went in the opposite direction of where I origianlly wanted to go with this PR, but given that we are adding correctness, I think we should do this. I had to make a few modifications in the code to fix the issues that this arose.
  - init_from_buf and some other static functions were missing type hints for the return type.

- Also fixed some small indentation issue and trailing white space that Claude found in the review of the generated code.

PR in project-x: https://gitlab.dev.figure.ai/figure/project-x/-/merge_requests/34382